### PR TITLE
add slack notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ python:
   - "2.7"
 compiler:
   - gcc
+notifications:
+  slack: jsk-robotics:Av7tc8wj3IWkLYvlTzHE7x2g
 env:
   - ROS_DISTRO=hydro AFTER_INSTALL=""
   - ROS_DISTRO=hydro AFTER_INSTALL="" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu


### PR DESCRIPTION
at this moment slack channel is only one who notify me if (other's) PR is passed or not, e-mail only gives "MY" PR, so we need to check repo manually to see if other's PR has passed

cons: introducing new channel is just consusing everyone

https://github.com/travis-ci/travis-core/pull/373