### PR TITLE
Ignore error of `wstool info`

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -145,7 +145,7 @@ fi
 
 travis_time_end
 
-$ROSWS info -t .
+$ROSWS info -t . || echo "Ignore error"
 cd ../
 
 travis_time_start catkin_build


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_recognition/pull/1172

Don't know why but "wstool info" recently fails with following error

```
+ wstool info -t .
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/wstool/common.py", line 283, in run
    result_dict = self.worker.do_work()
  File "/usr/lib/python2.7/dist-packages/wstool/multiproject_cmd.py", line 470, in do_work
    path_spec = self.element.get_versioned_path_spec(fetch=fetch)
  File "/usr/lib/python2.7/dist-packages/wstool/config_elements.py", line 414, in get_versioned_path_spec
    remote_revision = self._get_vcsc().get_remote_version(fetch=fetch)
AttributeError: 'GitClient' object has no attribute 'get_remote_version'
ERROR in config: Error processing 'jsk_recognition' : 'GitClient' object has no attribute 'get_remote_version'
```