### PR TITLE
[README.md] add documents to how to release package

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,19 @@ see [this document](https://github.com/jsk-ros-pkg/jsk_common#restart-travis-fro
 
   If [`USE_DEB`](#environmental-variables) is `false`, `.travis.rosinstall` is used to generate ROS workspace.
   You can specify distribution by `.travis.rosinstall.{{ ROS_DISTRO }}` like `.travis.rosinstall.indigo`.
+
+
+## Release Pakcage
+
+* relesing jsk_travis package is a bit tricky, due to existance of CATKIN_IGNORE file
+
+```
+mv CATKIN_IGNORE CATKIN_IGNORE.bak
+catkin_generate_changelog --skip-merges
+emacs -nw CHANGELOG.rst                 # prettify CHANGELOG so we can understand what has changed
+git commit -m "update CHANGELOG" CHANGELOG.rst
+catkin_prepare_release --no-push        # please type "Y" to all
+mv CATKIN_IGNORE CATKIN_IGNORE.bak      # do not forget this
+gitk                                    # make sure that what you changed is correct
+git push && git push --tags
+```


### PR DESCRIPTION
since jsk_travis is not compiled on build firm, I'd recommend to add package version, specially if you have significant changes.
so users link `jsk_travis@xxxx` for github web interface and jump to jsk-ros-pkg/jsk_travis page, then they can immediatly understand what version is used.