### PR TITLE
Source devel/setup.bash before run test to update ROS_PACKAGE_PATH for rostest

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -177,6 +177,7 @@ if [ "$ROS_DISTRO" == "hydro" ]; then
     (cd /opt/ros/$ROS_DISTRO/share; wget --no-check-certificate https://patch-diff.githubusercontent.com/raw/ros/ros_comm/pull/611.diff -O - | sed s@.cmake.em@.cmake@ | sed 's@/${PROJECT_NAME}@@' | sed 's@ DEPENDENCIES ${_rostest_DEPENDENCIES})@)@' | sudo patch -f -p2 || echo "ok")
 fi
 
+if [ "$BUILDER" == catkin ]; then source devel/setup.bash ; fi # force to update ROS_PACKAGE_PATH for rostest
 if [ "$BUILDER" == catkin ]; then catkin run_tests --no-deps --limit-status-rate 0.001 $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS --; fi
 # it seems catkin run_tests write test result to wrong place, and ceate MISSING...
 if [ "$BUILDER" == catkin ]; then  find build -iname MISSING* -print -exec rm {} \;; catkin_test_results build || error  ; fi


### PR DESCRIPTION
Sometime rostest fails to find script.
By sourcing `devel/setup.bash`, force to update ROS_PACKAGE_PATH before catkin runs tests.

```
-- run_tests.py: execute commands
  /opt/ros/jade/share/rostest/cmake/../../../bin/rostest --pkgdir=/workspace/ros/ws_jsk_common/src/jsk_common/jsk_network_tools --package=jsk_network_tools --results-filename test_test_all_type_low_speed.xml --results-base-dir /workspace/ros/ws_jsk_common/build/jsk_network_tools/test_results /workspace/ros/ws_jsk_common/src/jsk_common/jsk_network_tools/test/test_all_type_low_speed.test 
... logging to /workspace/jsk-ros-pkg/jsk_common/log/rostest-33058eefe459-8046.log
[ROSUNIT] Outputting test results to /workspace/ros/ws_jsk_common/build/jsk_network_tools/test_results/jsk_network_tools/rostest-test_test_all_type_low_speed.xml
testtest_all_type_low_speed ... FAILURE!
FAILURE: Package [jsk_network_tools] for test node [jsk_network_tools/test_all_type_low_speed.py] does not exist
  File "/usr/lib/python2.7/unittest/case.py", line 331, in run
    testMethod()
  File "/opt/ros/jade/lib/python2.7/dist-packages/rostest/runner.py", line 93, in fn
    self.fail(message)
  File "/usr/lib/python2.7/unittest/case.py", line 412, in fail
    raise self.failureException(msg)
--------------------------------------------------------------------------------
[ROSTEST]-----------------------------------------------------------------------
[testtest_all_type_low_speed][failed]
SUMMARY
 * RESULT: FAIL
 * TESTS: 0
 * ERRORS: 0
 * FAILURES: 1
```