### PR TITLE
[travis.sh][check_metapackage.py] use parser for detecting metapackage

### DIFF
--- a/check_metapackage.py
+++ b/check_metapackage.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+
+from xml.etree import ElementTree
+import sys
+
+p = ElementTree.parse(sys.argv[1])
+sys.exit(p.find('.//export/metapackage') == None)

--- a/travis.sh
+++ b/travis.sh
@@ -131,7 +131,7 @@ if [ "$USE_DEB" == source -a -e $REPOSITORY_NAME/setup_upstream.sh ]; then $ROSW
 # disable hrpsys/doc generation
 find . -ipath "*/hrpsys/CMakeLists.txt" -exec sed -i s'@if(ENABLE_DOXYGEN)@if(0)@' {} \;
 # disable metapackage
-find -L . -name package.xml -print -exec grep metapackage {} \; -a -exec bash -c 'touch `dirname ${1}`/CATKIN_IGNORE' funcname {} \;
+find -L . -name package.xml -print -exec ${CI_SOURCE_PATH}/.travis/check_metapackage.py {} \; -a -exec bash -c 'touch `dirname ${1}`/CATKIN_IGNORE' funcname {} \;
 
 # Install dependencies for source repos
 if [ "$ROSDEP_UPDATE_QUIET" == "true" ]; then


### PR DESCRIPTION
This PR fixes the bug of misdetecting xml:
https://github.com/jsk-ros-pkg/jsk_demos/blob/master/interactive_behavior_201409/package.xml#L25

In test:

```bash
+ find -L . -name package.xml -print -exec grep metapackage '{}' ';' -a -exec bash -c 'touch `dirname ${1}`/CATKIN_IGNORE' funcname '{}' ';'
....
/jsk_demos/interactive_behavior_201409/package.xml

    <!-- You can specify that this package is a metapackage here: -->

    <!-- <metapackage/> -->  # miss detect!!
```
