### PR TITLE
Purge mongodb setting.

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -72,7 +72,7 @@ if [ "$EXTRA_DEB" ]; then sudo apt-get install -q -qq -y $EXTRA_DEB;  fi
 # MongoDB hack - I don't fully understand this but its for moveit_warehouse
 dpkg -s mongodb || echo "ok"; export HAVE_MONGO_DB=$?
 if [ $HAVE_MONGO_DB == 0 ]; then
-    sudo apt-get remove -q -qq -y mongodb mongodb-10gen || echo "ok"
+    sudo apt-get remove --purge -q -qq -y mongodb mongodb-10gen || echo "ok"
     sudo apt-get install -q -qq -y mongodb-clients mongodb-server -o Dpkg::Options::="--force-confdef" || echo "ok"
 fi # default actions
 


### PR DESCRIPTION
[travis.sh] Purge mongodb setting.
In rtmros_common,
https://s3.amazonaws.com/archive.travis-ci.org/jobs/97132276/log.txt
mongodb configuration waiting occurs.

This can be resolved by adding `--purge` option and I tested this adding on `hrpsys-base`.
https://github.com/fkanehiro/hrpsys-base/pull/900#issuecomment-162392884

