### PR TITLE
[travis_jenkins.py] named docker container

### DIFF
--- a/travis_jenkins.py
+++ b/travis_jenkins.py
@@ -97,7 +97,7 @@ git submodule update
 # sudo docker rm -f `sudo docker ps --no-trunc -a -q` || echo "ok"
 sudo docker rmi $(sudo docker images | awk '/^&lt;none&gt;/ { print $3 }') || echo "oK"
 
-sudo docker run --rm -t -e ROS_DISTRO='%(ROS_DISTRO)s' -e ROSWS='%(ROSWS)s' -e BUILDER='%(BUILDER)s' -e USE_DEB='%(USE_DEB)s' -e TRAVIS_REPO_SLUG='%(TRAVIS_REPO_SLUG)s' -e EXTRA_DEB='%(EXTRA_DEB)s' -e TARGET_PKGS='%(TARGET_PKGS)s' -e BEFORE_SCRIPT='%(BEFORE_SCRIPT)s' -e TEST_PKGS='%(TEST_PKGS)s' -e NOT_TEST_INSTALL='%(NOT_TEST_INSTALL)s' -e ROS_PARALLEL_JOBS='%(ROS_PARALLEL_JOBS)s' -e CATKIN_PARALLEL_JOBS='%(CATKIN_PARALLEL_JOBS)s' -e ROS_PARALLEL_TEST_JOBS='%(ROS_PARALLEL_TEST_JOBS)s' -e CATKIN_PARALLEL_TEST_JOBS='%(CATKIN_PARALLEL_TEST_JOBS)s' -e BUILD_PKGS='%(BUILD_PKGS)s'  -e HOME=/workspace -v $WORKSPACE/${BUILD_TAG}:/workspace -v /export/data1/ccache:/workspace/.ccache -v /export/data1/pip-cache:/workspace/.cache/pip -v /export/data1/ros_test_data:/workspace/.ros/test_data -w /workspace ros-ubuntu:%(LSB_RELEASE)s /bin/bash -c "$(cat &lt;&lt;EOL
+sudo docker run --rm -t --name %(DOCKER_CONTAINER_NAME)s -e ROS_DISTRO='%(ROS_DISTRO)s' -e ROSWS='%(ROSWS)s' -e BUILDER='%(BUILDER)s' -e USE_DEB='%(USE_DEB)s' -e TRAVIS_REPO_SLUG='%(TRAVIS_REPO_SLUG)s' -e EXTRA_DEB='%(EXTRA_DEB)s' -e TARGET_PKGS='%(TARGET_PKGS)s' -e BEFORE_SCRIPT='%(BEFORE_SCRIPT)s' -e TEST_PKGS='%(TEST_PKGS)s' -e NOT_TEST_INSTALL='%(NOT_TEST_INSTALL)s' -e ROS_PARALLEL_JOBS='%(ROS_PARALLEL_JOBS)s' -e CATKIN_PARALLEL_JOBS='%(CATKIN_PARALLEL_JOBS)s' -e ROS_PARALLEL_TEST_JOBS='%(ROS_PARALLEL_TEST_JOBS)s' -e CATKIN_PARALLEL_TEST_JOBS='%(CATKIN_PARALLEL_TEST_JOBS)s' -e BUILD_PKGS='%(BUILD_PKGS)s'  -e HOME=/workspace -v $WORKSPACE/${BUILD_TAG}:/workspace -v /export/data1/ccache:/workspace/.ccache -v /export/data1/pip-cache:/workspace/.cache/pip -v /export/data1/ros_test_data:/workspace/.ros/test_data -w /workspace ros-ubuntu:%(LSB_RELEASE)s /bin/bash -c "$(cat &lt;&lt;EOL
 
 cd %(TRAVIS_REPO_SLUG)s
 set -x
@@ -232,6 +232,7 @@ CATKIN_PARALLEL_JOBS    = env.get('CATKIN_PARALLEL_JOBS') or ''
 ROS_PARALLEL_TEST_JOBS  = env.get('ROS_PARALLEL_TEST_JOBS') or ''
 CATKIN_PARALLEL_TEST_JOBS = env.get('CATKIN_PARALLEL_TEST_JOBS') or ''
 BUILD_PKGS       = env.get('BUILD_PKGS') or ''
+DOCKER_CONTAINER_NAME = '_'.join([TRAVIS_REPO_SLUG.replace('/','.'), TRAVIS_JOB_ID])
 
 print('''
 TRAVIS_BRANCH        = %(TRAVIS_BRANCH)s
@@ -257,6 +258,7 @@ CATKIN_PARALLEL_JOBS    = %(CATKIN_PARALLEL_JOBS)s
 ROS_PARALLEL_TEST_JOBS  = %(ROS_PARALLEL_TEST_JOBS)s
 CATKIN_PARALLEL_TEST_JOBS = %(CATKIN_PARALLEL_TEST_JOBS)s
 BUILD_PKGS       = %(BUILD_PKGS)s
+DOCKER_CONTAINER_NAME   = %(DOCKER_CONTAINER_NAME)s
 ''' % locals())
 
 if env.get('ROS_DISTRO') == 'hydro':


### PR DESCRIPTION
Naming docker container makes it easy to access afterward.


If docker container is run with the name
```
DOCKER_CONTAINER_NAME = jsk-ros-pkg.jsk_travis_97931434 # for example
```

we can attach to the container by

```bash
docker start jsk-ros-pkg.jsk_travis_97931434
docker attach jsk-ros-pkg.jsk_travis_97931434
root@xxxxxxx:/# 
```