### PR TITLE
keep containers for a while

### DIFF
--- a/travis_jenkins.py
+++ b/travis_jenkins.py
@@ -102,10 +102,12 @@ fi
 git submodule init
 git submodule update
 
-# sudo docker rm -f `sudo docker ps --no-trunc -a -q` || echo "ok"
-sudo docker rmi $(sudo docker images | awk '/^&lt;none&gt;/ { print $3 }') || echo "oK"
+# remove containers created/exited more than 48 hours ago
+for container in `sudo docker ps -a | egrep '^.*days ago' | awk '{print $1}'`; do
+     sudo docker rm $container || echo ok
+done
 
-sudo docker run --rm -t --name %(DOCKER_CONTAINER_NAME)s -e ROS_DISTRO='%(ROS_DISTRO)s' -e ROSWS='%(ROSWS)s' -e BUILDER='%(BUILDER)s' -e USE_DEB='%(USE_DEB)s' -e TRAVIS_REPO_SLUG='%(TRAVIS_REPO_SLUG)s' -e EXTRA_DEB='%(EXTRA_DEB)s' -e TARGET_PKGS='%(TARGET_PKGS)s' -e BEFORE_SCRIPT='%(BEFORE_SCRIPT)s' -e TEST_PKGS='%(TEST_PKGS)s' -e NOT_TEST_INSTALL='%(NOT_TEST_INSTALL)s' -e ROS_PARALLEL_JOBS='%(ROS_PARALLEL_JOBS)s' -e CATKIN_PARALLEL_JOBS='%(CATKIN_PARALLEL_JOBS)s' -e ROS_PARALLEL_TEST_JOBS='%(ROS_PARALLEL_TEST_JOBS)s' -e CATKIN_PARALLEL_TEST_JOBS='%(CATKIN_PARALLEL_TEST_JOBS)s' -e BUILD_PKGS='%(BUILD_PKGS)s'  -e HOME=/workspace -v $WORKSPACE/${BUILD_TAG}:/workspace -v /export/data1/ccache:/workspace/.ccache -v /export/data1/pip-cache:/workspace/.cache/pip -v /export/data1/ros_test_data:/workspace/.ros/test_data -w /workspace ros-ubuntu:%(LSB_RELEASE)s /bin/bash -c "$(cat &lt;&lt;EOL
+sudo docker run -t --name %(DOCKER_CONTAINER_NAME)s -e ROS_DISTRO='%(ROS_DISTRO)s' -e ROSWS='%(ROSWS)s' -e BUILDER='%(BUILDER)s' -e USE_DEB='%(USE_DEB)s' -e TRAVIS_REPO_SLUG='%(TRAVIS_REPO_SLUG)s' -e EXTRA_DEB='%(EXTRA_DEB)s' -e TARGET_PKGS='%(TARGET_PKGS)s' -e BEFORE_SCRIPT='%(BEFORE_SCRIPT)s' -e TEST_PKGS='%(TEST_PKGS)s' -e NOT_TEST_INSTALL='%(NOT_TEST_INSTALL)s' -e ROS_PARALLEL_JOBS='%(ROS_PARALLEL_JOBS)s' -e CATKIN_PARALLEL_JOBS='%(CATKIN_PARALLEL_JOBS)s' -e ROS_PARALLEL_TEST_JOBS='%(ROS_PARALLEL_TEST_JOBS)s' -e CATKIN_PARALLEL_TEST_JOBS='%(CATKIN_PARALLEL_TEST_JOBS)s' -e BUILD_PKGS='%(BUILD_PKGS)s'  -e HOME=/workspace -v $WORKSPACE/${BUILD_TAG}:/workspace -v /export/data1/ccache:/workspace/.ccache -v /export/data1/pip-cache:/workspace/.cache/pip -v /export/data1/ros_test_data:/workspace/.ros/test_data -w /workspace ros-ubuntu:%(LSB_RELEASE)s /bin/bash -c "$(cat &lt;&lt;EOL
 
 cd %(TRAVIS_REPO_SLUG)s
 set -x


### PR DESCRIPTION
this enables for hackers to debug by attaching finished docker containers in jenkins