### PR TITLE
Stop setting testing repository in wstool workspace

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -134,7 +134,6 @@ if [ "$USE_DEB" == false ]; then
         $ROSWS merge file://$CI_SOURCE_PATH/.travis.rosinstall.$ROS_DISTRO
     fi
     $ROSWS update
-    $ROSWS set $REPOSITORY_NAME http://github.com/$TRAVIS_REPO_SLUG --git -y
 fi
 ln -s $CI_SOURCE_PATH . # Link the repo we are testing to the new workspace
 if [ "$USE_DEB" == source -a -e $REPOSITORY_NAME/setup_upstream.sh ]; then $ROSWS init .; $REPOSITORY_NAME/setup_upstream.sh -w ~/ros/ws_$REPOSITORY_NAME ; $ROSWS update; fi


### PR DESCRIPTION
This is because `wstool update` after this line: for example, in BEFORE_SCRIPT,
changes the version of the testing repository. This causes problem.