### PR TITLE
Refactor: Abolish ROSWS and BUILDER environmental variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,13 @@ env:
   - ROS_DISTRO=hydro AFTER_INSTALL="ros-hydro-roseus"
   - ROS_DISTRO=hydro BEFORE_SCRIPT="pwd; git clone http://github.com/jsk-ros-pkg/jsk_common_msgs"
   - ROS_DISTRO=hydro USE_JENKINS="true" NO_SUDO="true"
-  - ROS_DISTRO=indigo BUILDER='not-compile'
-  - ROS_DISTRO=indigo BUILDER='not-compile' TRAVIS_REPO_SLUG=jsk-ros-pkg/jsk_travis
-  - ROS_DISTRO=indigo BUILDER='not-compile' TRAVIS_REPO_SLUG=jsk-ros-pkg/jsk_travis TRAVIS_BRANCH=master TRAVIS_COMMIT='HEAD' TRAVIS_PULL_REQUEST='false'
-  - ROS_DISTRO=jade BUILDER='not-compile'
-  - ROS_DISTRO=jade BUILDER='not-compile' TRAVIS_REPO_SLUG=jsk-ros-pkg/jsk_travis
-  - ROS_DISTRO=jade BUILDER='not-compile' TRAVIS_REPO_SLUG=jsk-ros-pkg/jsk_travis TRAVIS_BRANCH=master TRAVIS_COMMIT='HEAD' TRAVIS_PULL_REQUEST='false'
-  - ROS_DISTRO=kinetic BUILDER='not-compile'
+  - ROS_DISTRO=indigo
+  - ROS_DISTRO=indigo TRAVIS_REPO_SLUG=jsk-ros-pkg/jsk_travis
+  - ROS_DISTRO=indigo TRAVIS_REPO_SLUG=jsk-ros-pkg/jsk_travis TRAVIS_BRANCH=master TRAVIS_COMMIT='HEAD' TRAVIS_PULL_REQUEST='false'
+  - ROS_DISTRO=jade
+  - ROS_DISTRO=jade TRAVIS_REPO_SLUG=jsk-ros-pkg/jsk_travis
+  - ROS_DISTRO=jade TRAVIS_REPO_SLUG=jsk-ros-pkg/jsk_travis TRAVIS_BRANCH=master TRAVIS_COMMIT='HEAD' TRAVIS_PULL_REQUEST='false'
+  - ROS_DISTRO=kinetic
 before_script:
   - mkdir .travis; cp -r * .travis # need to copy, since directory starting from . is ignoreed by catkin build
   - export BEFORE_SCRIPT="rm -fr jsk_travis/CATKIN_IGNORE; ${BEFORE_SCRIPT}"

--- a/travis.sh
+++ b/travis.sh
@@ -25,6 +25,10 @@ function travis_time_end {
 # set default values to env variables
 [ "${USE_TRAVIS// }" = "" ] && USE_TRAVIS=false
 
+# Deprecated environmental variables
+[ ! -z $BUILDER -a "$BUILDER" != catkin ] && ( echo "ERROR: $BUILDER is not supported. BUILDER env is deprecated and only 'catkin' is supported for the build."; exit 1; )
+[ ! -z $ROSWS -a "$ROSWS" != wstool ] && ( echo "ERROR: $ROSWS is not supported. ROSWS env is deprecated and only 'wstool' is supported for workspace management."; exit 1; )
+
 if [ "$USE_TRAVIS" != "true" ] && [ "$ROS_DISTRO" == "indigo" -o "$ROS_DISTRO" == "jade" -o "$ROS_DISTRO" == "kinetic" -o "${USE_JENKINS}" == "true" ] && [ "$TRAVIS_JOB_ID" ]; then
     pip install --user python-jenkins -q
     ./.travis/travis_jenkins.py
@@ -36,11 +40,6 @@ function error {
     trap - ERR
     exit 1
 }
-
-[ "$BUILDER" == rosbuild ] && ( echo "$BUILDER is no longer supported"; exit 1; )
-[ "$ROSWS" == rosws ] && ( echo "$ROSWS is no longer supported"; exit 1; )
-BUILDER=catkin
-ROSWS=wstool
 
 trap error ERR
 

--- a/travis.sh
+++ b/travis.sh
@@ -128,19 +128,19 @@ catkin init
 catkin config $CATKIN_TOOLS_CONFIG_OPTIONS
 cd ~/ros/ws_$REPOSITORY_NAME/src
 if [ "$USE_DEB" == false ]; then
-    $ROSWS init .
+    wstool init .
     if [ -e $CI_SOURCE_PATH/.travis.rosinstall ]; then
         # install (maybe unreleased version) dependencies from source
-        $ROSWS merge file://$CI_SOURCE_PATH/.travis.rosinstall
+        wstool merge file://$CI_SOURCE_PATH/.travis.rosinstall
     fi
     if [ -e $CI_SOURCE_PATH/.travis.rosinstall.$ROS_DISTRO ]; then
         # install (maybe unreleased version) dependencies from source for specific ros version
-        $ROSWS merge file://$CI_SOURCE_PATH/.travis.rosinstall.$ROS_DISTRO
+        wstool merge file://$CI_SOURCE_PATH/.travis.rosinstall.$ROS_DISTRO
     fi
-    $ROSWS update
+    wstool update
 fi
 ln -s $CI_SOURCE_PATH . # Link the repo we are testing to the new workspace
-if [ "$USE_DEB" == source -a -e $REPOSITORY_NAME/setup_upstream.sh ]; then $ROSWS init .; $REPOSITORY_NAME/setup_upstream.sh -w ~/ros/ws_$REPOSITORY_NAME ; $ROSWS update; fi
+if [ "$USE_DEB" == source -a -e $REPOSITORY_NAME/setup_upstream.sh ]; then wstool init .; $REPOSITORY_NAME/setup_upstream.sh -w ~/ros/ws_$REPOSITORY_NAME ; wstool update; fi
 # disable hrpsys/doc generation
 find . -ipath "*/hrpsys/CMakeLists.txt" -exec sed -i s'@if(ENABLE_DOXYGEN)@if(0)@' {} \;
 # disable metapackage
@@ -177,8 +177,8 @@ fi
 
 travis_time_end
 
-$ROSWS --version
-$ROSWS info -t .
+wstool --version
+wstool info -t .
 cd ../
 
 travis_time_start catkin_build
@@ -188,11 +188,9 @@ source /opt/ros/$ROS_DISTRO/setup.bash > /tmp/$$.x 2>&1; grep export\ [^_] /tmp/
 # for catkin
 if [ "${TARGET_PKGS// }" == "" ]; then export TARGET_PKGS=`catkin_topological_order ${CI_SOURCE_PATH} --only-names`; fi
 if [ "${TEST_PKGS// }" == "" ]; then export TEST_PKGS=$( [ "${BUILD_PKGS// }" == "" ] && echo "$TARGET_PKGS" || echo "$BUILD_PKGS"); fi
-if [ "$BUILDER" == catkin ]; then
-  set -o pipefail  # this is necessary to pipe fail status on grepping
-  catkin build $CATKIN_TOOLS_BUILD_OPTIONS $BUILD_PKGS $CATKIN_PARALLEL_JOBS --make-args $ROS_PARALLEL_JOBS | grep -v -e Symlinking -e Linked
-  set +o pipefail
-fi
+set -o pipefail  # this is necessary to pipe fail status on grepping
+catkin build $CATKIN_TOOLS_BUILD_OPTIONS $BUILD_PKGS $CATKIN_PARALLEL_JOBS --make-args $ROS_PARALLEL_JOBS | grep -v -e Symlinking -e Linked
+set +o pipefail
 
 travis_time_end
 travis_time_start catkin_run_tests
@@ -204,13 +202,11 @@ if [ "$ROS_DISTRO" == "hydro" ]; then
     (cd /opt/ros/$ROS_DISTRO/share; wget --no-check-certificate https://patch-diff.githubusercontent.com/raw/ros/ros_comm/pull/611.diff -O - | sed s@.cmake.em@.cmake@ | sed 's@/${PROJECT_NAME}@@' | sed 's@ DEPENDENCIES ${_rostest_DEPENDENCIES})@)@' | sudo patch -f -p2 || echo "ok")
 fi
 
-if [ "$BUILDER" == catkin ]; then
-    source devel/setup.bash > /tmp/$$.x 2>&1; grep export\ [^_] /tmp/$$.x ; rospack profile # force to update ROS_PACKAGE_PATH for rostest
-    set -o pipefail  # this is necessary to pipe fail status on grepping
-    catkin run_tests -i --no-deps --no-status $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS -- | grep -v -e Symlinking -e Linked -e :[^\s]*install[^\s]*\]
-    set +o pipefail
-    catkin_test_results --verbose --all build || error
-fi
+source devel/setup.bash > /tmp/$$.x 2>&1; grep export\ [^_] /tmp/$$.x ; rospack profile # force to update ROS_PACKAGE_PATH for rostest
+set -o pipefail  # this is necessary to pipe fail status on grepping
+catkin run_tests -i --no-deps --no-status $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS -- | grep -v -e Symlinking -e Linked -e :[^\s]*install[^\s]*\]
+set +o pipefail
+catkin_test_results --verbose --all build || error
 
 travis_time_end
 
@@ -218,38 +214,34 @@ if [ "$NOT_TEST_INSTALL" != "true" ]; then
 
     travis_time_start catkin_install_build
 
-    if [ "$BUILDER" == catkin ]; then
-        catkin clean --yes || catkin clean -a # 0.3.1 uses -a, 0.4.0 uses --yes
-        catkin config --install $CATKIN_TOOLS_CONFIG_OPTIONS
-        set -o pipefail  # this is necessary to pipe fail status on grepping
-        catkin build $CATKIN_TOOLS_BUILD_OPTIONS $BUILD_PKGS $CATKIN_PARALLEL_JOBS --make-args $ROS_PARALLEL_JOBS | grep -v -e Symlinking -e Linked -e :[^\s]*install[^\s]*\]
-        set +o pipefail
-        source install/setup.bash > /tmp/$$.x 2>&1; grep export\ [^_] /tmp/$$.x
-        rospack profile
-        rospack plugins --attrib=plugin nodelet || echo "ok"
-    fi
+    catkin clean --yes || catkin clean -a # 0.3.1 uses -a, 0.4.0 uses --yes
+    catkin config --install $CATKIN_TOOLS_CONFIG_OPTIONS
+    set -o pipefail  # this is necessary to pipe fail status on grepping
+    catkin build $CATKIN_TOOLS_BUILD_OPTIONS $BUILD_PKGS $CATKIN_PARALLEL_JOBS --make-args $ROS_PARALLEL_JOBS | grep -v -e Symlinking -e Linked -e :[^\s]*install[^\s]*\]
+    set +o pipefail
+    source install/setup.bash > /tmp/$$.x 2>&1; grep export\ [^_] /tmp/$$.x
+    rospack profile
+    rospack plugins --attrib=plugin nodelet || echo "ok"
 
     travis_time_end
     travis_time_start catkin_install_run_tests
 
     export EXIT_STATUS=0
-    if [ "$BUILDER" == catkin ]; then
-      for pkg in $TEST_PKGS; do
-        echo "[$pkg] Started testing..."
-        rostest_files=$(find install/share/$pkg -iname '*.test')
-        echo "[$pkg] Found $(echo $rostest_files | wc -w) tests."
-        for test_file in $rostest_files; do
-          echo "[$pkg] Testing $test_file"
-          rostest $test_file || export EXIT_STATUS=$?
-          if [ $? != 0 ]; then
-            echo -e "[$pkg] Testing again the failed test: $test_file.\e[31m>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\e[0m"
-            rostest --text $test_file
-            echo -e "[$pkg] Testing again the failed test: $test_file.\e[31m<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\e[0m"
-          fi
-        done
+    for pkg in $TEST_PKGS; do
+      echo "[$pkg] Started testing..."
+      rostest_files=$(find install/share/$pkg -iname '*.test')
+      echo "[$pkg] Found $(echo $rostest_files | wc -w) tests."
+      for test_file in $rostest_files; do
+        echo "[$pkg] Testing $test_file"
+        rostest $test_file || export EXIT_STATUS=$?
+        if [ $? != 0 ]; then
+          echo -e "[$pkg] Testing again the failed test: $test_file.\e[31m>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\e[0m"
+          rostest --text $test_file
+          echo -e "[$pkg] Testing again the failed test: $test_file.\e[31m<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\e[0m"
+        fi
       done
-      [ $EXIT_STATUS -eq 0 ] || error  # unless all tests pass, raise error
-    fi
+    done
+    [ $EXIT_STATUS -eq 0 ] || error  # unless all tests pass, raise error
 
     travis_time_end
 
@@ -261,8 +253,8 @@ travis_time_start after_script
 PATH=/usr/local/bin:$PATH  # for installed catkin_test_results
 PYTHONPATH=/usr/local/lib/python2.7/dist-packages:$PYTHONPATH
 if [ "${ROS_LOG_DIR// }" == "" ]; then export ROS_LOG_DIR=~/.ros/test_results; fi # http://wiki.ros.org/ROS/EnvironmentVariables#ROS_LOG_DIR
-if [ "$BUILDER" == catkin -a -e $ROS_LOG_DIR ]; then catkin_test_results --verbose --all $ROS_LOG_DIR || error; fi
-if [ "$BUILDER" == catkin -a -e ~/ros/ws_$REPOSITORY_NAME/build/ ]; then catkin_test_results --verbose --all ~/ros/ws_$REPOSITORY_NAME/build/ || error; fi
-if [ "$BUILDER" == catkin -a -e ~/.ros/test_results/ ]; then catkin_test_results --verbose --all ~/.ros/test_results/ || error; fi
+if [ -e $ROS_LOG_DIR ]; then catkin_test_results --verbose --all $ROS_LOG_DIR || error; fi
+if [ -e ~/ros/ws_$REPOSITORY_NAME/build/ ]; then catkin_test_results --verbose --all ~/ros/ws_$REPOSITORY_NAME/build/ || error; fi
+if [ -e ~/.ros/test_results/ ]; then catkin_test_results --verbose --all ~/.ros/test_results/ || error; fi
 
 travis_time_end

--- a/travis_jenkins.py
+++ b/travis_jenkins.py
@@ -22,8 +22,6 @@ CONFIGURE_XML = '''<?xml version='1.0' encoding='UTF-8'?>
      &lt;/h4&gt;
      Parameters are&lt;br&gt;
        ROS_DISTRO = %(ROS_DISTRO)s&lt;br&gt;
-       ROSWS      = %(ROSWS)s&lt;br&gt;
-       BUILDIER   = %(BUILDER)s&lt;br&gt;
        USE_DEB    = %(USE_DEB)s&lt;br&gt;
        EXTRA_DEB  = %(EXTRA_DEB)s&lt;br&gt;
        TARGET_PKGS = %(TARGET_PKGS)s&lt;br&gt;
@@ -116,8 +114,6 @@ sudo docker rm %(DOCKER_CONTAINER_NAME)s || echo  "docker rm %(DOCKER_CONTAINER_
 sudo docker run %(DOCKER_RUN_OPTION)s -t \\
     --name %(DOCKER_CONTAINER_NAME)s \\
     -e ROS_DISTRO='%(ROS_DISTRO)s' \\
-    -e ROSWS='%(ROSWS)s' \\
-    -e BUILDER='%(BUILDER)s' \\
     -e USE_DEB='%(USE_DEB)s' \\
     -e TRAVIS_REPO_SLUG='%(TRAVIS_REPO_SLUG)s' \\
     -e EXTRA_DEB='%(EXTRA_DEB)s' \\
@@ -263,8 +259,6 @@ TRAVIS_BUILD_NUMBER = env.get('TRAVIS_BUILD_NUMBER')
 TRAVIS_JOB_ID = env.get('TRAVIS_JOB_ID')
 TRAVIS_JOB_NUMBER = env.get('TRAVIS_JOB_NUMBER')
 ROS_DISTRO = env.get('ROS_DISTRO', 'indigo')
-ROSWS = env.get('ROSWS', 'wstool')
-BUILDER = env.get('BUILDER', 'catkin')
 USE_DEB = env.get('USE_DEB', 'true')
 EXTRA_DEB = env.get('EXTRA_DEB', '')
 TEST_PKGS = env.get('TEST_PKGS', '')
@@ -293,8 +287,6 @@ TRAVIS_JOB_ID        = %(TRAVIS_JOB_ID)s
 TRAVIS_JOB_NUMBER    = %(TRAVIS_JOB_NUMBER)s
 TRAVIS_BRANCH        = %(TRAVIS_BRANCH)s
 ROS_DISTRO       = %(ROS_DISTRO)s
-ROSWS            = %(ROSWS)s
-BUILDER          = %(BUILDER)s
 USE_DEB          = %(USE_DEB)s
 EXTRA_DEB        = %(EXTRA_DEB)s
 TEST_PKGS        = %(TEST_PKGS)s


### PR DESCRIPTION
## Summary

1. Stop using ROSWS and BUILDER in travis.sh
2. Raise error when ROSWS != wstool or BUILDER != catkin (this is same behavior before)
3. Remove ROSWS and BUILDER env when running on Jenkins


## NOTE

The 3rd change breaks the tests when user uses ROSWS or BUILDER environmental variable
in BEFORE_SCRIPT on Jenkins. (but this is too rare to happen, I think)