### PR TITLE
Exit soon when Jenkins server is down

### DIFF
--- a/travis_jenkins.py
+++ b/travis_jenkins.py
@@ -228,6 +228,10 @@ def wait_for_finished(name, number):
             print('ERROR: Jenkins job name={0}, number={1} in server={2}'
                   'not found.'.format(name, number, j.server))
             return
+        except jenkins.JenkinsException, e:
+            print('ERROR: Maybe Jenkins server is down. Please visit {0}'
+                  .format(j.server))
+            return
         except Exception, e:
             print(e)
         if loop % (display/sleep) == 0:


### PR DESCRIPTION
This lets us more productive by shorten the waiting time for 2h when
    Jenkins is dead.