### PR TITLE
Stable testing with retry=3 in example.test

### DIFF
--- a/example.test
+++ b/example.test
@@ -7,5 +7,5 @@
   <param name="hztest1/test_duration" value="5.0" />    
   <param name="hztest1/wait_time" value="21.0" />    
   <test test-name="hztest_test" pkg="rostest" type="hztest"
-        name="hztest1" />
+        name="hztest1" retry="3" />
 </launch>


### PR DESCRIPTION
Found https://github.com/jsk-ros-pkg/jsk_travis/pull/268

```
-------------------------------------------------
<?xml version="1.0" encoding="utf-8"?>
<testsuite errors="0" failures="1" name="unittest.suite.TestSuite" tests="1" time="5.217">
  <testcase classname="__main__.HzTest" name="test_hz" time="5.2173">
    <failure type="AssertionError">average rate (8.226Hz) exceeded minimum (9.500Hz)
  File "/usr/lib/python2.7/unittest/case.py", line 327, in run
    testMethod()
  File "/opt/ros/hydro/share/rostest/nodes/hztest/hztest", line 115, in test_hz
    self._test_hz(hz, hzerror, topic, test_duration, wait_time)
  File "/opt/ros/hydro/share/rostest/nodes/hztest/hztest", line 185, in _test_hz
    (rate, self.min_rate))
  File "/usr/lib/python2.7/unittest/case.py", line 420, in assertTrue
    raise self.failureException(msg)
    </failure>
  </testcase>
  <system-out><![CDATA[Hz: 10.0
Hz Error: 0.5
Topic: chatter
Test Duration: 5.0
Waiting for messages
Starting rate measurement
Done waiting, validating results
]]></system-out>
  <system-err><![CDATA[]]></system-err>
</testsuite>

```