### PR TITLE
Fix #275: Set timeout for sudo docker ps -a command

### DIFF
--- a/travis_jenkins.py
+++ b/travis_jenkins.py
@@ -107,7 +107,8 @@ git submodule init
 git submodule update
 
 # remove containers created/exited more than 48 hours ago
-for container in `sudo docker ps -a | egrep '^.*days ago' | awk '{print $1}'`; do
+timeout 10s sudo docker ps -a > /tmp/$$.docker_ps_a.txt || exit 1  # check docker isn't held up
+for container in `cat $$.docker_ps_a.txt | egrep '^.*days ago' | awk '{print $1}'`; do
      sudo docker rm $container || echo ok
 done
 


### PR DESCRIPTION
Fix #275 

This makes the job exit soon, and developers can aware of it.