### PR TITLE
Stop using HEAD version catkin on hydro

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -103,7 +103,7 @@ travis_time_start setup_catkin
 ### https://github.com/ros/catkin/pull/705
 if [ "$ROS_DISTRO" == "hydro" ]; then
   [ ! -e /tmp/catkin ] && (cd /tmp/; git clone -q https://github.com/ros/catkin)
-  (cd /tmp/catkin; cmake . -DCMAKE_INSTALL_PREFIX=/opt/ros/$ROS_DISTRO/ ; make; sudo make install)
+  (cd /tmp/catkin; git checkout 1b5f6fb2f0a3460c45885e26e7fa9ca1e52f1b87; cmake . -DCMAKE_INSTALL_PREFIX=/opt/ros/$ROS_DISTRO/ ; make; sudo make install)
 else
   sudo apt-get install -y --force-yes -q -qq ros-$ROS_DISTRO-catkin
 fi


### PR DESCRIPTION
I found this is necessary in addition to https://github.com/jsk-ros-pkg/jsk_travis/pull/284