### PR TITLE
Fix typo in generating job name: a-f -> a-z

### DIFF
--- a/travis_jenkins.py
+++ b/travis_jenkins.py
@@ -373,7 +373,7 @@ job_name = '-'.join(
         ]
     )
 )
-job_name = re.sub(r'[^0-9A-Fa-f]+', '-', job_name)
+job_name = re.sub(r'[^0-9A-Za-z]+', '-', job_name)
 if j.job_exists(job_name) is None:
     j.create_job(job_name, jenkins.EMPTY_CONFIG_XML)
 


### PR DESCRIPTION
Just a typo. Sorry.