### PR TITLE
Set CATKIN_TOOLS_BUILD_OPTIONS after the installation of catkin-tools

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -63,14 +63,6 @@ if [ ! "$ROS_PARALLEL_TEST_JOBS" ]; then export ROS_PARALLEL_TEST_JOBS="$ROS_PAR
 if [ ! "$CATKIN_PARALLEL_TEST_JOBS" ]; then export CATKIN_PARALLEL_TEST_JOBS="$CATKIN_PARALLEL_JOBS";  fi
 if [ ! "$ROS_REPOSITORY_PATH" ]; then export ROS_REPOSITORY_PATH="http://packages.ros.org/ros-shadow-fixed/ubuntu"; fi
 if [ ! "$ROSDEP_ADDITIONAL_OPTIONS" ]; then export ROSDEP_ADDITIONAL_OPTIONS="-n -q -r --ignore-src"; fi
-if [ ! "$CATKIN_TOOLS_BUILD_OPTIONS" ]; then
-  if [[ "$(pip show catkin-tools | grep '^Version:' | awk '{print $2}')" =~ 0.3.[0-9]+ ]]; then
-    # For catkin-tools==0.3.X, '-iv' option is required to get the stderr output.
-    export CATKIN_TOOLS_BUILD_OPTIONS="-iv --summarize --no-status"
-  else
-    export CATKIN_TOOLS_BUILD_OPTIONS="--summarize --no-status"
-  fi
-fi
 echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
 # Setup pip
 # FIXME: need to specify pip version to 6.0.7 to avoid unexpected error
@@ -83,6 +75,15 @@ wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
 lsb_release -a
 sudo apt-get update -q || echo Ignore error of apt-get update
 sudo apt-get install -y --force-yes -q -qq python-rosdep python-wstool python-catkin-tools ros-$ROS_DISTRO-rosbash ros-$ROS_DISTRO-rospack ccache
+# setup catkin-tools option
+if [ ! "$CATKIN_TOOLS_BUILD_OPTIONS" ]; then
+  if [[ "$(pip show catkin-tools | grep '^Version:' | awk '{print $2}')" =~ 0.3.[0-9]+ ]]; then
+    # For catkin-tools==0.3.X, '-iv' option is required to get the stderr output.
+    export CATKIN_TOOLS_BUILD_OPTIONS="-iv --summarize --no-status"
+  else
+    export CATKIN_TOOLS_BUILD_OPTIONS="--summarize --no-status"
+  fi
+fi
 # setup ccache
 sudo ln -s /usr/bin/ccache /usr/local/bin/gcc
 sudo ln -s /usr/bin/ccache /usr/local/bin/g++


### PR DESCRIPTION
This is a bug.
The version must be set after the installation of python-catkin-tools.