### PR TITLE
[dummy.xorg.conf] update for supporting GLX

### DIFF
--- a/dummy.xorg.conf
+++ b/dummy.xorg.conf
@@ -1,21 +1,24 @@
 Section "Device"
-    Identifier  "Configured Video Device"
+    Identifier  "VideoCard0"
     Driver      "dummy"
+    Option "NoDDC" "true"
+    Option "IgnoreEDID" "true"
 EndSection
 
 Section "Monitor"
-    Identifier  "Configured Monitor"
+    Identifier  "Monitor0"
     HorizSync 31.5-48.5
     VertRefresh 50-70
+    Modeline "1224x685" 67.72 1224 1280 1408 1592 685 686 689 709 -HSync +Vsync
 EndSection
 
 Section "Screen"
-    Identifier  "Default Screen"
-    Monitor     "Configured Monitor"
-    Device      "Configured Video Device"
+    Identifier  "Screen0"
+    Monitor     "Monitor0"
+    Device      "VideoCard0"
     DefaultDepth 24
     SubSection "Display"
-    Depth 24
-    Modes "800x600"
+        Depth 24
+        Modes "1224x685"
     EndSubSection
 EndSection


### PR DESCRIPTION
This solves #320 
A main reason that disables GLX extension is missing modeline configuration on monitor.