### PR TITLE
[travis_jenkins.py] delete: remove containers more than 48 hours ago

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ see [this document](https://github.com/jsk-ros-pkg/jsk_common#restart-travis-fro
 * `USE_DOCKER` (default: `false`)
 
   Force to use docker on travis.
+  
+* `DOCKER_RUN_OPTION` (default: `--rm`)
+
+  Options passed to `docker run` if `USE_DOCKER` is `true`. Ignored otherwise.  
+  **NOTE** If `--rm` is not set, the container remains even after job is finished. You must be responsible for removing it.
 
 * `USE_JENKINS` (default: `false`)
 

--- a/travis_jenkins.py
+++ b/travis_jenkins.py
@@ -109,13 +109,6 @@ if [ "%(REPOSITORY_NAME)s" = "jsk_travis" ]; then
   mkdir .travis; cp -r * .travis # need to copy, since directory starting from . is ignoreed by catkin build
 fi
 
-# remove containers created/exited more than 48 hours ago
-timeout 10s sudo docker ps -a > /tmp/$$.docker_ps_a.txt || exit 1  # check docker isn't held up
-for container in `cat /tmp/$$.docker_ps_a.txt | egrep '^.*days ago' | awk '{print $1}'`; do
-     sudo docker rm $container || echo ok
-done
-rm -f /tmp/$$.docker_ps_a.txt
-
 # run watchdog for kill orphan docker container
 .travis/travis_watchdog.py %(DOCKER_CONTAINER_NAME)s --sudo &amp;
 


### PR DESCRIPTION
now default docker option is `--rm` and no container will not be remained.
After this pull request is merged, I remove all `*docker_ps_a.txt` in jenkins server.