### PR TITLE
Set TARGET_PKGS to BUILD_PKGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,18 @@ see [this document](https://github.com/jsk-ros-pkg/jsk_common#restart-travis-fro
   Some characters won't work without escaping it for xml on Jenkins.
   (see: [here](https://github.com/jsk-ros-pkg/jsk_travis/issues/171))
 
+* `TARGET_PKGS` (default: none)
+
+  If none, it is set by `catkin_topological_order ${CI_SOURCE_PATH} --only-names`, and used to set
+   - `TEST_PKGS` that is used at `catkin run_tests`
+   - `BUILD_PKGS` if its value is `TARGET_PKGS`
+
 * `BUILD_PKGS` (default: none)
 
   You can specify the packages to build and test. If your repository has some troubles about several packages,
   you can ignore them by this option like `BUILD_PKGS="jsk_pcl_ros jsk_recognition_msgs"`.
+  Default value is none and all packages in the workspace will be built,
+  and if it is `"TARGET_PKGS"`, `$TARGET_PKGS` will be set to `BUILD_PKGS`.
 
 * `EXTRA_DEB` (default: none)
 

--- a/travis.sh
+++ b/travis.sh
@@ -272,6 +272,7 @@ travis_time_start catkin_build
 source /opt/ros/$ROS_DISTRO/setup.bash > /tmp/$$.x 2>&1; grep export\ [^_] /tmp/$$.x # re-source setup.bash for setting environmet vairable for package installed via rosdep
 # for catkin
 if [ "${TARGET_PKGS// }" == "" ]; then export TARGET_PKGS=`catkin_topological_order ${CI_SOURCE_PATH} --only-names`; fi
+if [ "${BUILD_PKGS// }" == "TARGET_PKGS" ]; then export BUILD_PKGS="$TARGET_PKGS"; fi
 if [ "${TEST_PKGS// }" == "" ]; then export TEST_PKGS=$( [ "${BUILD_PKGS// }" == "" ] && echo "$TARGET_PKGS" || echo "$BUILD_PKGS"); fi
 if [ -z $TRAVIS_JOB_ID ]; then
   # on Jenkins


### PR DESCRIPTION
Close https://github.com/jsk-ros-pkg/jsk_travis/issues/328

To build not all packages in workspace, but only target packages, because depending packages should be built automatically by seeing the dependency graph.