### PR TITLE
Add option to use custom docker image in Jenkins job

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ see [this document](https://github.com/jsk-ros-pkg/jsk_common#restart-travis-fro
 * `USE_DOCKER` (default: `false`)
 
   Force to use docker on travis.
-  
+
+* `DOCKER_IMAGE_JENKINS` (defualt: `ros-ubuntu:$(lsb_release -sr)`)
+
+  Docker image used in Jenkins.
+
 * `DOCKER_RUN_OPTION` (default: `--rm`)
 
   Options passed to `docker run` if `USE_DOCKER` is `true`. Ignored otherwise.  

--- a/travis_jenkins.py
+++ b/travis_jenkins.py
@@ -140,7 +140,7 @@ sudo docker run %(DOCKER_RUN_OPTION)s -t \\
     -v /export/data1/ros_data:/workspace/.ros/data \\
     -v /export/data1/ros_test_data:/workspace/.ros/test_data \\
     -v /tmp/.X11-unix:/tmp/.X11-unix:rw \\
-    -w /workspace ros-ubuntu:%(LSB_RELEASE)s /bin/bash \\
+    -w /workspace %(DOCKER_IMAGE_JENKINS)s /bin/bash \\
     -c "$(cat &lt;&lt;EOL
 
 cd %(TRAVIS_REPO_SLUG)s
@@ -352,6 +352,8 @@ elif env.get('ROS_DISTRO') == 'kinetic':
 else:
     LSB_RELEASE = '14.04'
     UBUNTU_DISTRO = 'trusty'
+
+DOCKER_IMAGE_JENKINS = env.get('DOCKER_IMAGE_JENKINS', 'ros-ubuntu:%s' % LSB_RELEASE)
 
 ### start here
 j = Jenkins('http://jenkins.jsk.imi.i.u-tokyo.ac.jp:8080/', 'k-okada', '22f8b1c4812dad817381a05f41bef16b')


### PR DESCRIPTION
## Why?

I'd like to use pcl1.8 built image in Jenkins to boost the test time.