### PR TITLE
use language: c++ , to avoid custom python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 #   Generic MoveIt Travis Continuous Integration Configuration File
 #   Works with all MoveIt! repositories/branches
 #   Author: Dave Coleman, Jonathan Bohren
-language: generic
+language: c++
 cache:
   apt: true
   pip: true


### PR DESCRIPTION
need to use system python, with travis-python we can not find python module install by apt
c.f. jsk-ros-pkg/jsk_3rdparty#117