### PR TITLE
to run docker, we do not need -ti option

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -86,7 +86,7 @@ if [ "$USE_DOCKER" = true ]; then
   export QT_X11_NO_MITSHM=1 # http://wiki.ros.org/docker/Tutorials/GUI
   xhost +local:root
 
-  docker run -it -v $HOME:$HOME \
+  docker run -v $HOME:$HOME \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
     -e QT_X11_NO_MITSHM -e DISPLAY \
     -e TRAVIS_BRANCH -e TRAVIS_COMMIT -e TRAVIS_JOB_ID -e TRAVIS_OS_NAME -e TRAVIS_PULL_REQUEST -e TRAVIS_REPO_SLUG \

--- a/travis_jenkins.py
+++ b/travis_jenkins.py
@@ -115,7 +115,7 @@ fi
 
 sudo docker stop %(DOCKER_CONTAINER_NAME)s || echo "docker stop %(DOCKER_CONTAINER_NAME)s ends with $?"
 sudo docker rm %(DOCKER_CONTAINER_NAME)s || echo  "docker rm %(DOCKER_CONTAINER_NAME)s ends with $?"
-sudo docker run %(DOCKER_RUN_OPTION)s -t \\
+sudo docker run %(DOCKER_RUN_OPTION)s \\
     --name %(DOCKER_CONTAINER_NAME)s \\
     -e ROS_DISTRO='%(ROS_DISTRO)s' \\
     -e USE_DEB='%(USE_DEB)s' \\


### PR DESCRIPTION
```
   -i, --interactive             Keep STDIN open even if not attached
   -t, --tty                     Allocate a pseudo-TTY
```

-i is set on travis, but not on jenkins, so we can remove this
-t can be removed, with this, hrpsys writing beep command `dev/console` is also shown in terminanl and that makes huge log