### PR TITLE
use http instaed of https

### DIFF
--- a/travis_jenkins.py
+++ b/travis_jenkins.py
@@ -89,7 +89,7 @@ WORKSPACE=`pwd`
 trap "pwd; sudo rm -fr $WORKSPACE/${BUILD_TAG} || echo 'ok'" EXIT
 
 # try git clone until success
-until git clone http://github.com/%(TRAVIS_REPO_SLUG)s ${BUILD_TAG}/%(TRAVIS_REPO_SLUG)s
+until git clone https://github.com/%(TRAVIS_REPO_SLUG)s ${BUILD_TAG}/%(TRAVIS_REPO_SLUG)s
 do
   echo "Retrying"
 done


### PR DESCRIPTION
not sure why, but as of 2017.08.19, clone http is so slow..., not status warning -> https://status.github.com/messages

```
$ git clone http://github.com/github/hub
Cloning into 'hub'...
fatal: unable to access 'http://github.com/github/hub/': Recv failure: Connectio
n reset by peer
$ git clone https://github.com/github/hub
Cloning into 'hub'...
remote: Counting objects: 14189, done.
remote: Compressing objects: 100% (31/31), done.
remote: Total 14189 (delta 31), reused 40 (delta 22), pack-reused 14136
Receiving objects: 100% (14189/14189), 3.79 MiB | 0 bytes/s, done.
Resolving deltas: 100% (8982/8982), done.
Checking connectivity... done.

```