### PR TITLE
when rosdep install is called with -r, do not exit with 1

### DIFF
--- a/rosdep-install.sh
+++ b/rosdep-install.sh
@@ -20,4 +20,7 @@ fi
 
 find -L . -name manifest.xml.deprecated | xargs -n 1 -i dirname {} | xargs -n 1 -i mv `pwd`/{}/manifest.xml.deprecated `pwd`/{}/manifest.xml
 
+#if -r is included in ROSDEP_ADDITIONAL_OPTIONS, always returns true
+[[ "$ROSDEP_ADDITIONAL_OPTIONS" =~ " -r " ]] && exit 0
+
 exit $EXIT_STATUS


### PR DESCRIPTION
```
executing command [sudo -H apt-get install -y -qq python-oauth2]
E: Unable to locate package python-oauth2
dpkg-query: no packages found matching python-oauth2
ERROR: the following rosdeps failed to install
  apt: command [sudo -H apt-get install -y -qq python-oauth2] failed
  apt: Failed to detect successful installation of [python-oauth2]
+ EXIT_STATUS=1
+ '[' 1 == 0 ']'
+ sleep 30
+ '[' 1 == 1 -a 3 -lt 3 ']'
+ '[' 1 '!=' 0 ']'
+ rosdep install -q -y --rosdistro kinetic -n -q -r --ignore-src --from-paths /opt/ros/kinetic/share .
dpkg-query: no packages found matching python-oauth2
dpkg-query: no packages found matching python-oauth2
executing command [sudo -H apt-get install -y -qq python-oauth2]
E: Unable to locate package python-oauth2
dpkg-query: no packages found matching python-oauth2
ERROR: the following rosdeps failed to install
  apt: command [sudo -H apt-get install -y -qq python-oauth2] failed
  apt: Failed to detect successful installation of [python-oauth2]
+ EXIT_STATUS=1
+ find -L . -name manifest.xml.deprecated
+ xargs -n 1 -i dirname '{}'
++ pwd
++ pwd
+ xargs -n 1 -i mv '/home/travis/ros/ws_jsk_3rdparty/src/{}/manifest.xml.deprecated' '/home/travis/ros/ws_jsk_3rdparty/src/{}/manifest.xml'
+ exit 1
+++ error
+++ travis_time_end 31
+++ set +x
```