### PR TITLE
https://github.com/ros-infrastructure/rosdep/pull/612 has been released

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -152,6 +152,7 @@ sudo -E sh -c 'echo "deb $ROS_REPOSITORY_PATH `lsb_release -cs` main" > /etc/apt
 wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
 lsb_release -a
 sudo apt-get update -q || echo Ignore error of apt-get update
+sudo apt-get install -y --force-yes -q -qq dpkg # https://github.com/travis-ci/travis-ci/issues/9361#issuecomment-408431262 dpkg-deb: error: archive has premature member 'control.tar.xz' before 'control.tar.gz' #9361
 sudo apt-get install -y --force-yes -q -qq python-rosdep python-wstool python-catkin-tools ros-$ROS_DISTRO-rosbash ros-$ROS_DISTRO-rospack ccache
 # setup catkin-tools option
 if [ ! "$CATKIN_TOOLS_BUILD_OPTIONS" ]; then

--- a/travis.sh
+++ b/travis.sh
@@ -259,8 +259,6 @@ travis_time_end
 
 travis_time_start rosdep_install
 
-## add https://github.com/ros-infrastructure/rosdep/pull/612
-(cd /usr/lib/python2.7/dist-packages; wget --no-check-certificate https://patch-diff.githubusercontent.com/raw/ros-infrastructure/rosdep/pull/612.diff -O /tmp/612.diff; sudo patch -p2 < /tmp/612.diff)
 if [ -e ${CI_SOURCE_PATH}/.travis/rosdep-install.sh ]; then ## this is mainly for jsk_travis itself
     ${CI_SOURCE_PATH}/.travis/rosdep-install.sh
 else


### PR DESCRIPTION
this has been released as rosdep 0.13.0 -> https://github.com/ros-infrastructure/rosdep/pull/612#issuecomment-436774123

```
## add https://github.com/ros-infrastructure/rosdep/pull/612
(cd /usr/lib/python2.7/dist-packages; wget --no-check-certificate https://patch-diff.githubusercontent.com/raw/ros-infrastructure/rosdep/pull/612.diff -O /tmp/612.diff; sudo patch -p2 < /tmp/612.diff)
```
outputs error when 612.diff is already merged
```
+ sudo patch -p2
patching file rosdep2/platforms/debian.py
Reversed (or previously applied) patch detected!  Assume -R? [n] 
Apply anyway? [n] 
Skipping patch.
1 out of 1 hunk ignored -- saving rejects to file rosdep2/platforms/debian.py.rej
++ error
++ travis_time_end 31
++ set +x
```

![image](https://user-images.githubusercontent.com/493276/48256619-7f106700-e453-11e8-8331-ccd526c1540a.png)
