### PR TITLE
use --merge-replace -y for .travis.rosinstall.$ROS_DISTRO

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -264,7 +264,7 @@ if [ "$USE_DEB" == false ]; then
     fi
     if [ -e $CI_SOURCE_PATH/.travis.rosinstall.$ROS_DISTRO ]; then
         # install (maybe unreleased version) dependencies from source for specific ros version
-        wstool merge file://$CI_SOURCE_PATH/.travis.rosinstall.$ROS_DISTRO
+        wstool merge --merge-replace -y file://$CI_SOURCE_PATH/.travis.rosinstall.$ROS_DISTRO
     fi
     wstool update
 fi


### PR DESCRIPTION
to enable override the .ros.rosinstall by .travis.rosinstall.$ROS_DISTRO