### PR TITLE
Specify test results directory

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -428,6 +428,8 @@ PYTHONPATH=/usr/local/lib/python2.7/dist-packages:$PYTHONPATH
 if [ "${ROS_LOG_DIR// }" == "" ]; then export ROS_LOG_DIR=~/.ros/test_results; fi # http://wiki.ros.org/ROS/EnvironmentVariables#ROS_LOG_DIR
 if [ -e $ROS_LOG_DIR ]; then catkin_test_results --verbose --all $ROS_LOG_DIR || error; fi
 if [ -e ~/ros/ws_$REPOSITORY_NAME/build/ ]; then catkin_test_results --verbose --all ~/ros/ws_$REPOSITORY_NAME/build/ || error; fi
-if [ -e ~/.ros/test_results/ ]; then catkin_test_results --verbose --all ~/.ros/test_results/ || error; fi
+for pkg in $TEST_PKGS; do
+    if [ -e ~/.ros/test_results/$pkg/ ]; then catkin_test_results --verbose --all ~/.ros/test_results/$pkg/ || error; fi
+done
 
 travis_time_end


### PR DESCRIPTION
Test results saved under `~/.ros/test_results` may contain packages from multiple repositories like jsk_recognition, rtmros_common.
https://github.com/jsk-ros-pkg/jsk_recognition/pull/2446#issuecomment-524767020

In this PR, test results of packages which matches `$TEST_PKGS` will be shown and the others will be ignored.
