### PR TITLE
Share only downloaded data in ~/.ros/ among all docker process on jenkins

### DIFF
--- a/travis_jenkins.py
+++ b/travis_jenkins.py
@@ -114,7 +114,8 @@ echo "TRAVIS_JENKINS_UNIQUE_ID : %(TRAVIS_JENKINS_UNIQUE_ID)s"
 # setup cache dir
 mkdir -p /data/cache/%(ROS_DISTRO)s/ccache
 mkdir -p /data/cache/%(ROS_DISTRO)s/pip-cache
-mkdir -p /data/cache/%(ROS_DISTRO)s/ros
+mkdir -p /data/cache/%(ROS_DISTRO)s/ros/data
+mkdir -p /data/cache/%(ROS_DISTRO)s/ros/rosdep
 
 #
 docker ps -a
@@ -147,7 +148,8 @@ docker run %(DOCKER_RUN_OPTION)s \\
     -v $WORKSPACE/${BUILD_TAG}:/workspace \\
     -v /data/cache/%(ROS_DISTRO)s/ccache:/workspace/.ccache \\
     -v /data/cache/%(ROS_DISTRO)s/pip-cache:/root/.cache/pip \\
-    -v /data/cache/%(ROS_DISTRO)s/ros:/workspace/.ros \\
+    -v /data/cache/%(ROS_DISTRO)s/ros/data:/workspace/.ros/data \\
+    -v /data/cache/%(ROS_DISTRO)s/ros/rosdep:/workspace/.ros/rosdep \\
     -v /tmp/.X11-unix:/tmp/.X11-unix:rw \\
     -w /workspace %(DOCKER_IMAGE_JENKINS)s /bin/bash \\
     -c "$(cat &lt;&lt;EOL


### PR DESCRIPTION
Related to https://github.com/jsk-ros-pkg/jsk_travis/pull/383#pullrequestreview-279928036, but this PR does not require https://github.com/jsk-ros-pkg/jsk_travis/pull/383.

In this PR, we prevent each docker process on jenkins from sharing data under `~/.ros/` other than downloaded data.
Here "downloaded data" means ...
- large size data such as rosbag and trained neural network weight (Downloaded when `jsk_data/download_data` is called)
- rosdep sources cache (Updated during `rosdep update`)