### PR TITLE
Add --force-yes to install EXTRA_DEB

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -212,7 +212,7 @@ sudo ln -s /usr/bin/ccache /usr/local/bin/cc
 sudo ln -s /usr/bin/ccache /usr/local/bin/c++
 ccache -s
 
-if [ "$EXTRA_DEB" ]; then sudo apt-get install -q -qq -y $EXTRA_DEB;  fi
+if [ "$EXTRA_DEB" ]; then sudo apt-get install -q -qq -y --force-yes $EXTRA_DEB;  fi
 # MongoDB hack - I don't fully understand this but its for moveit_warehouse
 dpkg -s mongodb || echo "ok"; export HAVE_MONGO_DB=$?
 if [ $HAVE_MONGO_DB == 0 ]; then


### PR DESCRIPTION
To fix https://github.com/start-jsk/rtmros_common/pull/1077#issuecomment-549629846

Another solution is to [add apt-key update](https://askubuntu.com/questions/75565/why-am-i-getting-authentication-errors-for-packages-from-an-ubuntu-repository), but I select to add `--force-yes` because other `apt-get install`s in `travis.sh` have `--force-yes`.