### PR TITLE
Don't use HTTP proxy for HTTPS urls for apt-cacher-ng

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -120,6 +120,10 @@ glxinfo | grep GLX
 
 # set up apt-cache docker
 echo 'Acquire::http {proxy "http://172.17.0.1:3142"; };' | sudo tee /etc/apt/apt.conf.d/02proxy.conf
+# to fix https://github.com/jsk-ros-pkg/jsk_travis/pull/388#issuecomment-549735323
+# see https://matoken.org/blog/2019/07/19/direct-access-to-https-repository-with-apt-cacher-ng/
+# see https://github.com/sameersbn/docker-apt-cacher-ng/tree/3.1#usage
+echo 'Acquire::https {proxy "false"; };' | sudo tee -a /etc/apt/apt.conf.d/02proxy.conf
 
 # ensure setting testing environment same as travis
 export USE_JENKINS=false

--- a/test/gazebo.test
+++ b/test/gazebo.test
@@ -7,23 +7,23 @@
         args="-sdf -file $(find jsk_travis)/test/camera.sdf -model cam"/>
 
   <test test-name="gazebo_sanity_checker" pkg="rostest" type="hztest"
-        retry="3" time-limit="600">
+        retry="3" time-limit="300">
     <rosparam>
       topic: /gazebo/model_states
       hz: 1000.0
       hzerror: 800.0
       test_duration: 10.0
-      wait_time: 600.0
+      wait_time: 300.0
     </rosparam>
   </test>
   <test test-name="gazebo_camera_sanity_checker" pkg="rostest" type="hztest"
-        retry="3" time-limit="600">
+        retry="3" time-limit="300">
     <rosparam>
       topic: /camera/image_raw
       hz: 15.0
       hzerror: 15.0
       test_duration: 10.0
-      wait_time: 600.0
+      wait_time: 300.0
     </rosparam>
   </test>
 </launch>

--- a/test/gazebo.test
+++ b/test/gazebo.test
@@ -7,23 +7,23 @@
         args="-sdf -file $(find jsk_travis)/test/camera.sdf -model cam"/>
 
   <test test-name="gazebo_sanity_checker" pkg="rostest" type="hztest"
-        retry="3" time-limit="300">
+        retry="3" time-limit="600">
     <rosparam>
       topic: /gazebo/model_states
       hz: 1000.0
       hzerror: 800.0
       test_duration: 10.0
-      wait_time: 300.0
+      wait_time: 600.0
     </rosparam>
   </test>
   <test test-name="gazebo_camera_sanity_checker" pkg="rostest" type="hztest"
-        retry="3" time-limit="300">
+        retry="3" time-limit="600">
     <rosparam>
       topic: /camera/image_raw
       hz: 15.0
       hzerror: 15.0
       test_duration: 10.0
-      wait_time: 300.0
+      wait_time: 600.0
     </rosparam>
   </test>
 </launch>

--- a/travis_jenkins.py
+++ b/travis_jenkins.py
@@ -176,6 +176,10 @@ sudo ccache -M 30G                   # set maximum size of ccache to 30G
 
 # Enable apt-cacher-ng to cache apt packages
 echo 'Acquire::http {proxy "http://$(ifdata -pa docker0):3142"; };' | sudo tee /etc/apt/apt.conf.d/02proxy.conf
+# to fix https://github.com/jsk-ros-pkg/jsk_travis/pull/388#issuecomment-549735323
+# see https://matoken.org/blog/2019/07/19/direct-access-to-https-repository-with-apt-cacher-ng/
+# see https://github.com/sameersbn/docker-apt-cacher-ng/tree/3.1#usage
+echo 'Acquire::https {proxy "false"; };' | sudo tee -a /etc/apt/apt.conf.d/02proxy.conf
 sudo apt-get update -qq || echo Ignore error of apt-get update
 export SHELL=/bin/bash
 


### PR DESCRIPTION
To fix https://github.com/jsk-ros-pkg/jsk_travis/pull/388#issuecomment-549735323 and https://github.com/start-jsk/rtmros_common/pull/1077#issuecomment-549629846