### PR TITLE
Suppress the output of run_tests on jenkins

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -373,10 +373,14 @@ else
 fi
 if [ -z $TRAVIS_JOB_ID ]; then
   # on Jenkins
-  catkin run_tests -i --no-deps --no-status $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS $CMAKE_ARGS_FLAGS --
+  # suppressing the output
+  # - https://github.com/catkin/catkin_tools/issues/405
+  # - https://github.com/ros-planning/moveit_ci/pull/18
+  #catkin run_tests -i --no-deps --no-status $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS $CMAKE_ARGS_FLAGS --
+  catkin build --catkin-make-args run_tests -- -i --no-deps --no-status $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS $CMAKE_ARGS_FLAGS --
 else
   # on Travis
-  # supressing the output
+  # suppressing the output
   # - https://github.com/catkin/catkin_tools/issues/405
   # - https://github.com/ros-planning/moveit_ci/pull/18
   #travis_wait 60 catkin run_tests -i --no-deps --no-status $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS $CMAKE_ARGS_FLAGS --


### PR DESCRIPTION
~~Depends on #389~~ 
Jenkins version of #386 

This seems required to pass melodic test of https://github.com/jsk-ros-pkg/jsk_recognition/pull/2462,
because it succeeded on jenkins but failed on travis due to:
```
The job exceeded the maximum log length, and has been terminated.
```
(from https://api.travis-ci.org/v3/job/609114983/log.txt)
cc @YutoUchimi 