### PR TITLE
[WIP] Enable to pass additional environment variables to docker on travis/jenkins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ services:
 notifications:
   slack: jsk-robotics:Av7tc8wj3IWkLYvlTzHE7x2g
 env:
+  global:
+    # For testing ADDITIONAL_ENV_TO_DOCKER
+    - TEST_VAR1=true
+    - TEST_VAR2=false
+    - ADDITIONAL_ENV_TO_DOCKER='TEST_VAR1 TEST_VAR2'
   matrix:
     # travis + jsk jenkins
     - ROS_DISTRO=hydro USE_JENKINS="true" NO_SUDO="true"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ find_package(catkin REQUIRED rostest)
 catkin_package()
 add_rostest(test/example.test)
 
+if(CATKIN_ENABLE_TESTING)
+  # For testing ADDITIONAL_ENV_TO_DOCKER
+  catkin_add_nosetests(test/test_env_var.py)
+endif()
+
 set(ENABLE_TEST_GAZEBO OFF CACHE BOOL "Option to enable testing gazebo")
 if(ENABLE_TEST_GAZEBO)
   add_rostest(test/gazebo.test)

--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ see [this document](https://github.com/jsk-ros-pkg/jsk_common#restart-travis-fro
 
   Flag to show CMake developer error in catkin run_tests.
 
+* `ADDITIONAL_ENV_TO_DOCKER` (default: none)
+
+  Specify environment variables you want to pass to docker on travis/jenkins.
+  You can specify multiple variables separated by a space.  
+  e.g. `IS_EUSLISP_TRAVIS_TEST IS_GAZEBO_TRAVIS_TEST`
+
 ## Config Files
 
 * `.travis.rosinstall`, `.travis.rosinstall.{{ ROS_DISTRO }}`

--- a/test/test_env_var.py
+++ b/test/test_env_var.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+
+
+class TestEnvVar(unittest.TestCase):
+
+    def test_env_var(self):
+
+        self.assertTrue(os.getenv('TEST_VAR1', '') == 'true')
+        self.assertTrue(os.getenv('TEST_VAR2', '') == 'false')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/travis.sh
+++ b/travis.sh
@@ -114,6 +114,19 @@ if [ "$USE_DOCKER" = true ]; then
 
   fi
 
+  travis_time_start setup_docker_env_file
+
+  touch /tmp/docker_env_file
+  if [ "$ADDITIONAL_ENV_TO_DOCKER" != "" ]; then
+    env_list=(`echo "$ADDITIONAL_ENV_TO_DOCKER"`)
+    for env in ${env_list[@]}; do
+      echo "$env=${!env}" >> /tmp/docker_env_file
+    done
+  fi
+  cat /tmp/docker_env_file
+
+  travis_time_end
+
   docker pull $DOCKER_IMAGE || true
   docker run -v $HOME:$HOME -v $HOME/.ccache:$HOME/.ccache/ -v $HOME/.cache/pip:$HOME/.cache/pip/ \
     $DOCKER_XSERVER_OPTIONS \
@@ -128,6 +141,7 @@ if [ "$USE_DOCKER" = true ]; then
     -e ROSDEP_ADDITIONAL_OPTIONS -e ROSDEP_UPDATE_QUIET \
     -e SUDO_PIP -e USE_PYTHON_VIRTUALENV \
     -e NOT_TEST_INSTALL \
+    --env-file /tmp/docker_env_file \
     -t $DOCKER_IMAGE bash -c 'cd $CI_SOURCE_PATH; .travis/docker.sh'
   DOCKER_EXIT_CODE=$?
   sudo chown -R travis.travis $HOME/apt-cacher-ng

--- a/travis.sh
+++ b/travis.sh
@@ -116,14 +116,15 @@ if [ "$USE_DOCKER" = true ]; then
 
   travis_time_start setup_docker_env_file
 
-  touch /tmp/docker_env_file
+  DOCKER_ENV_FILE="/tmp/docker_env_file_$$"
+  touch $DOCKER_ENV_FILE
   if [ "$ADDITIONAL_ENV_TO_DOCKER" != "" ]; then
     env_list=(`echo "$ADDITIONAL_ENV_TO_DOCKER"`)
     for env in ${env_list[@]}; do
-      echo "$env=${!env}" >> /tmp/docker_env_file
+      echo "$env=${!env}" >> $DOCKER_ENV_FILE
     done
   fi
-  cat /tmp/docker_env_file
+  cat $DOCKER_ENV_FILE
 
   travis_time_end
 
@@ -141,9 +142,10 @@ if [ "$USE_DOCKER" = true ]; then
     -e ROSDEP_ADDITIONAL_OPTIONS -e ROSDEP_UPDATE_QUIET \
     -e SUDO_PIP -e USE_PYTHON_VIRTUALENV \
     -e NOT_TEST_INSTALL \
-    --env-file /tmp/docker_env_file \
+    --env-file $DOCKER_ENV_FILE \
     -t $DOCKER_IMAGE bash -c 'cd $CI_SOURCE_PATH; .travis/docker.sh'
   DOCKER_EXIT_CODE=$?
+  rm $DOCKER_ENV_FILE
   sudo chown -R travis.travis $HOME/apt-cacher-ng
   # sudo tail -n 100 /var/log/apt-cacher-ng/*
   # sudo find $HOME/apt-cacher-ng

--- a/travis_jenkins.py
+++ b/travis_jenkins.py
@@ -117,6 +117,16 @@ mkdir -p /data/cache/%(ROS_DISTRO)s/pip-cache
 mkdir -p /data/cache/%(ROS_DISTRO)s/ros/data
 mkdir -p /data/cache/%(ROS_DISTRO)s/ros/rosdep
 
+# setup docker env-file
+touch /tmp/docker_env_file
+if [ "%(ADD_ENV_VALUE_TO_DOCKER)s" != "" ]; then
+  env_var_list=(`echo "%(ADD_ENV_VALUE_TO_DOCKER)s"`)
+  for env_var in ${env_var_list[@]}; do
+    echo "$env_var" >> /tmp/docker_env_file
+  done
+fi
+cat /tmp/docker_env_file
+
 #
 docker ps -a
 if [ "$(docker ps -a | grep %(DOCKER_CONTAINER_NAME)s || true)" ] ; then
@@ -145,6 +155,7 @@ docker run %(DOCKER_RUN_OPTION)s \\
     -e ROSDEP_ADDITIONAL_OPTIONS='%(ROSDEP_ADDITIONAL_OPTIONS)s'  \\
     -e DOCKER_RUN_OPTION='%(DOCKER_RUN_OPTION)s'  \\
     -e HOME=/workspace \\
+    --env-file /tmp/docker_env_file \\
     -v $WORKSPACE/${BUILD_TAG}:/workspace \\
     -v /data/cache/%(ROS_DISTRO)s/ccache:/workspace/.ccache \\
     -v /data/cache/%(ROS_DISTRO)s/pip-cache:/root/.cache/pip \\
@@ -332,6 +343,14 @@ NUMBER_OF_LOGS_TO_KEEP = env.get('NUMBER_OF_LOGS_TO_KEEP', '30')
 REPOSITORY_NAME = env.get('REPOSITORY_NAME', '')
 TRAVIS_BUILD_WEB_URL = env.get('TRAVIS_BUILD_WEB_URL', '')
 TRAVIS_JOB_WEB_URL = env.get('TRAVIS_JOB_WEB_URL', '')
+ADDITIONAL_ENV_TO_DOCKER = env.get('ADDITIONAL_ENV_TO_DOCKER', '')
+ADD_ENV_VALUE_TO_DOCKER = ''
+tmp_list = []
+for add_env in ADDITIONAL_ENV_TO_DOCKER.split(' '):
+    if add_env != '':
+        add_env_val = env.get(add_env, '')
+        tmp_list.append(add_env + '=' + add_env_val)
+ADD_ENV_VALUE_TO_DOCKER = ' '.join(tmp_list)
 
 if env.get('ROS_DISTRO') == 'hydro':
     LSB_RELEASE = '12.04'
@@ -385,6 +404,7 @@ REPOSITORY_NAME = %(REPOSITORY_NAME)s
 TRAVIS_BUILD_WEB_URL = %(TRAVIS_BUILD_WEB_URL)s
 TRAVIS_JOB_WEB_URL = %(TRAVIS_JOB_WEB_URL)s
 DOCKER_IMAGE_JENKINS = %(DOCKER_IMAGE_JENKINS)s
+ADD_ENV_VALUE_TO_DOCKER = %(ADD_ENV_VALUE_TO_DOCKER)s
 ''' % locals())
 
 ### start here
@@ -490,6 +510,7 @@ REPOSITORY_NAME = %(REPOSITORY_NAME)s <br> \
 TRAVIS_BUILD_WEB_URL = %(TRAVIS_BUILD_WEB_URL)s <br> \
 TRAVIS_JOB_WEB_URL = %(TRAVIS_JOB_WEB_URL)s <br> \
 DOCKER_IMAGE_JENKINS = %(DOCKER_IMAGE_JENKINS)s <br> \
+ADD_ENV_VALUE_TO_DOCKER = %(ADD_ENV_VALUE_TO_DOCKER)s <br> \
 ') % locals())
 
 ## wait for result

--- a/travis_jenkins.py
+++ b/travis_jenkins.py
@@ -118,14 +118,15 @@ mkdir -p /data/cache/%(ROS_DISTRO)s/ros/data
 mkdir -p /data/cache/%(ROS_DISTRO)s/ros/rosdep
 
 # setup docker env-file
-touch /tmp/docker_env_file
+DOCKER_ENV_FILE="/tmp/docker_env_file_$$"
+touch $DOCKER_ENV_FILE
 if [ "%(ADD_ENV_VALUE_TO_DOCKER)s" != "" ]; then
   env_var_list=(`echo "%(ADD_ENV_VALUE_TO_DOCKER)s"`)
   for env_var in ${env_var_list[@]}; do
-    echo "$env_var" >> /tmp/docker_env_file
+    echo "$env_var" >> $DOCKER_ENV_FILE
   done
 fi
-cat /tmp/docker_env_file
+cat $DOCKER_ENV_FILE
 
 #
 docker ps -a
@@ -155,7 +156,7 @@ docker run %(DOCKER_RUN_OPTION)s \\
     -e ROSDEP_ADDITIONAL_OPTIONS='%(ROSDEP_ADDITIONAL_OPTIONS)s'  \\
     -e DOCKER_RUN_OPTION='%(DOCKER_RUN_OPTION)s'  \\
     -e HOME=/workspace \\
-    --env-file /tmp/docker_env_file \\
+    --env-file $DOCKER_ENV_FILE \\
     -v $WORKSPACE/${BUILD_TAG}:/workspace \\
     -v /data/cache/%(ROS_DISTRO)s/ccache:/workspace/.ccache \\
     -v /data/cache/%(ROS_DISTRO)s/pip-cache:/root/.cache/pip \\
@@ -210,6 +211,7 @@ glxinfo | grep GLX || echo "OK"
 
 EOL
 )"
+rm $DOCKER_ENV_FILE
 
      </command>
     </hudson.tasks.Shell>


### PR DESCRIPTION
Sometimes, we want to pass additional environment variables to docker on travis/jenkins, to switch testing.
e.g. `IS_EUSLISP_TRAVIS_TEST` in rtmros_common:
https://github.com/start-jsk/rtmros_common/blob/1.4.2/.travis.yml#L22
https://github.com/start-jsk/rtmros_common/blob/1.4.2/hrpsys_ros_bridge/CMakeLists.txt#L261

This PR enables that by new environment variable `ADDITIONAL_ENV_TO_DOCKER`.

- [x] Add document
- [x] Add test code