### PR TITLE
fix for https://github.com/start-jsk/rtmros_common/pull/1089

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ see [this document](https://github.com/jsk-ros-pkg/jsk_common#restart-travis-fro
   You can specify multiple variables separated by a space.  
   e.g. `IS_EUSLISP_TRAVIS_TEST IS_GAZEBO_TRAVIS_TEST`
 
+* `DEBUG_TRAVIS_PYTHON` (default: none)
+
+  Specify python command to run within travis/docker/jenkins,
+  for example set `DEBUG_TRAVIS_PYTHON` to `python -v`
+
 ## Config Files
 
 * `.travis.rosinstall`, `.travis.rosinstall.{{ ROS_DISTRO }}`

--- a/travis.sh
+++ b/travis.sh
@@ -162,7 +162,7 @@ if [ "$USE_TRAVIS" != "true" ] && [ "$ROS_DISTRO" != "hydro" -o "${USE_JENKINS}"
         python --version
     fi
     pip install --user -U python-jenkins==1.7.0 -q
-    ${DEBUG_TRAVIS_PYTHON} ./.travis/travis_jenkins.py
+    PYTHONIOENCODING=utf-8 ${DEBUG_TRAVIS_PYTHON} ./.travis/travis_jenkins.py
     return $?
 fi
 

--- a/travis.sh
+++ b/travis.sh
@@ -141,7 +141,7 @@ if [ "$USE_DOCKER" = true ]; then
     -e ROS_PARALLEL_JOBS -e ROS_PARALLEL_TEST_JOBS \
     -e ROSDEP_ADDITIONAL_OPTIONS -e ROSDEP_UPDATE_QUIET \
     -e SUDO_PIP -e USE_PYTHON_VIRTUALENV \
-    -e NOT_TEST_INSTALL \
+    -e NOT_TEST_INSTALL -e DEBUG_TRAVIS_PYTHON \
     --env-file $DOCKER_ENV_FILE \
     -t $DOCKER_IMAGE bash -c 'cd $CI_SOURCE_PATH; .travis/docker.sh'
   DOCKER_EXIT_CODE=$?
@@ -157,8 +157,12 @@ if [ "$USE_DOCKER" = true ]; then
 fi
 
 if [ "$USE_TRAVIS" != "true" ] && [ "$ROS_DISTRO" != "hydro" -o "${USE_JENKINS}" == "true" ] && [ "$TRAVIS_JOB_ID" ]; then
+    if [ "${DEBUG_TRAVIS_PYTHON}" != "" ]; then
+        pip --version
+        python --version
+    fi
     pip install --user -U python-jenkins==1.4.0 -q
-    ./.travis/travis_jenkins.py
+    ${DEBUG_TRAVIS_PYTHON} ./.travis/travis_jenkins.py
     return $?
 fi
 

--- a/travis.sh
+++ b/travis.sh
@@ -161,7 +161,7 @@ if [ "$USE_TRAVIS" != "true" ] && [ "$ROS_DISTRO" != "hydro" -o "${USE_JENKINS}"
         pip --version
         python --version
     fi
-    pip install --user -U python-jenkins==1.4.0 -q
+    pip install --user -U python-jenkins==1.7.0 -q
     ${DEBUG_TRAVIS_PYTHON} ./.travis/travis_jenkins.py
     return $?
 fi

--- a/travis_jenkins.py
+++ b/travis_jenkins.py
@@ -519,10 +519,10 @@ ADD_ENV_VALUE_TO_DOCKER = %(ADD_ENV_VALUE_TO_DOCKER)s <br> \
 result = wait_for_finished(job_name, build_number)
 
 ## show console
-print j.get_build_console_output(job_name, build_number)
-print "======================================="
-print j.get_build_info(job_name, build_number)['url']
-print "======================================="
+print (u"{}".format(j.get_build_console_output(job_name, build_number)))
+print (u"=======================================")
+print (u"{}".format(j.get_build_info(job_name, build_number)['url']))
+print (u"=======================================")
 if result == "SUCCESS" :
     exit(0)
 else:

--- a/travis_jenkins.py
+++ b/travis_jenkins.py
@@ -5,7 +5,10 @@
 import jenkins
 import requests
 import urllib
-import urllib2
+try:
+    import urllib2
+except:
+    import urllib.request, urllib.error
 import json
 import time
 import os
@@ -272,15 +275,15 @@ def wait_for_finished(name, number):
         now = time.time() * 1000
         try:
             info = j.get_build_info(name, number)
-        except jenkins.NotFoundException, e:
+        except jenkins.NotFoundException as e:
             print('ERROR: Jenkins job name={0}, number={1} in server={2}'
                   'not found.'.format(name, number, j.server))
             break
-        except jenkins.JenkinsException, e:
+        except jenkins.JenkinsException as e:
             print('ERROR: Maybe Jenkins server is down. Please visit {0}'
                   .format(j.server))
             break
-        except Exception, e:
+        except Exception as e:
             print('ERROR: Unexpected error: {0}'.format(e))
             break
         if not info['building']:
@@ -289,7 +292,7 @@ def wait_for_finished(name, number):
         # update progressbar
         progress = (now - info['timestamp']) / info['estimatedDuration']
         if loop % (display/sleep) == 0:
-            print info['url'], "building: ", info['building'], "result: ", info['result'], "progress: ", progress
+            print(info['url'], "building: ", info['building'], "result: ", info['result'], "progress: ", progress)
         time.sleep(sleep)
         loop += 1
     return result
@@ -456,7 +459,7 @@ while True:
 # wait for execution
 while True:
     item = j.get_queue_item(queue_number)
-    if item.has_key('executable'):
+    if 'executable' in item:
         item = item['executable']
         break;
     print("wait for execution....", item)


### PR DESCRIPTION
```
wait for queueing ... 待機中です。あと4.8 秒です。 
wait for queueing ... 待機中です。あと1.6 秒です。 
wait for queueing ... Finished waiting 
build number is 2025
(u'http://jenkins.jsk.imi.i.u-tokyo.ac.jp:8080/job/start-jsk-rtmros-common/2025/', 'building: ', True, 'result: ', None, 'progress: ', 0.0017260438356986312)
Traceback (most recent call last):
  File "./.travis/travis_jenkins.py", line 525, in <module>
    print (u"{}".format(j.get_build_console_output(job_name, build_number)))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-3: ordinal not in range(128)
```

https://travis-ci.org/github/start-jsk/rtmros_common/jobs/669644931?utm_source=github_status


-  PYTHONIOENCODING=utf-8 fix utf-8
-  support python3
- use python-jenkins 1.7.0

- set unicode for print console output
- add DEBUG_TRAVIS_PYTHON