### PR TITLE
update rosdep-install.sh for indigo, which does not read <*_depend condition="$ROS_PYTHON=VERSION == 2"> format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ add_rostest(test/example.test)
 if(CATKIN_ENABLE_TESTING)
   # For testing ADDITIONAL_ENV_TO_DOCKER
   catkin_add_nosetests(test/test_env_var.py)
-  # Check if rosdep is correctly install numpy
-  catkin_add_nosetests(test/test_numpy.py)
+  # Check if rosdep is correctly install scipy
+  catkin_add_nosetests(test/test_scipy.py)
 endif()
 
 set(ENABLE_TEST_GAZEBO OFF CACHE BOOL "Option to enable testing gazebo")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ add_rostest(test/example.test)
 if(CATKIN_ENABLE_TESTING)
   # For testing ADDITIONAL_ENV_TO_DOCKER
   catkin_add_nosetests(test/test_env_var.py)
+  # Check if rosdep is correctly install numpy
+  catkin_add_nosetests(test/test_numpy.py)
 endif()
 
 set(ENABLE_TEST_GAZEBO OFF CACHE BOOL "Option to enable testing gazebo")

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,8 @@
 
   <build_depend condition="$ROS_PYTHON_VERSION == 2">python</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 3">python3</build_depend>
+  <build_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</build_depend>
+  <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</build_depend>
   <build_depend>catkin</build_depend>
   <build_depend>rostest</build_depend>
   <test_depend>rospy_tutorials</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -14,8 +14,8 @@
 
   <build_depend condition="$ROS_PYTHON_VERSION == 2">python</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 3">python3</build_depend>
-  <build_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</build_depend>
-  <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</build_depend>
+  <build_depend condition="$ROS_PYTHON_VERSION == 2">python-scipy</build_depend>
+  <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-scipy</build_depend>
   <build_depend>catkin</build_depend>
   <build_depend>rostest</build_depend>
   <test_depend>rospy_tutorials</test_depend>

--- a/rosdep-install.sh
+++ b/rosdep-install.sh
@@ -2,6 +2,11 @@
 
 trap 'find -L . -name manifest.xml.deprecated | xargs -n 1 -i dirname {} | xargs -n 1 -i mv `pwd`/{}/manifest.xml.deprecated `pwd`/{}/manifest.xml' 1 2 3 15
 
+# for indigo, move package.xml to package.xml.org and remove condition
+if [[ "$ROS_DISTRO" =~ "hydro"|"indigo"|"jade" ]]; then
+   find -L . -iname package.xml -exec grep -l package\ format=\"3\" {} \; | xargs -n 1 -i cp {} {}.org
+   find -L . -iname package.xml -exec grep -l package\ format=\"3\" {} \; | xargs -n 1 -i sed -i 's/_depend condition="\$ROS_PYTHON_VERSION\s*==\s*2">/_depend>/' {}
+fi
 find -L . -name package.xml -exec dirname {} \; | xargs -n 1 -i find {} -name manifest.xml | xargs -n 1 -i mv {} {}.deprecated # rename manifest.xml for rosdep install
 PACKAGE_PATH_LIST=(${ROS_PACKAGE_PATH//:/\ /})
 ROS_PACKAGE_PATH_REVERSED=`for ((i=${#PACKAGE_PATH_LIST[@]}-1; i>=0; i--)); do if [ -e ${PACKAGE_PATH_LIST[$i]} ]; then echo -n ${PACKAGE_PATH_LIST[$i]}' '; fi; done`
@@ -19,6 +24,9 @@ if [ $EXIT_STATUS != 0 ]; then
 fi
 
 find -L . -name manifest.xml.deprecated | xargs -n 1 -i dirname {} | xargs -n 1 -i mv `pwd`/{}/manifest.xml.deprecated `pwd`/{}/manifest.xml
+if [[ "$ROS_DISTRO" =~ "hydro"|"indigo"|"jade" ]]; then
+    find -L . -iname package.xml.org -exec grep -l package\ format=\"3\" {} \; | xargs -n 1 -i cp  {}.org {}
+fi
 
 #if -r is included in ROSDEP_ADDITIONAL_OPTIONS, always returns true
 [[ "$ROSDEP_ADDITIONAL_OPTIONS" =~ " -r " ]] && exit 0

--- a/test/test_env_var.py
+++ b/test/test_env_var.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+
 import os
+import sys
 import unittest
 
 
@@ -9,6 +12,8 @@ class TestEnvVar(unittest.TestCase):
 
     def test_env_var(self):
 
+        print("TEST_VAR1 : " + os.getenv('TEST_VAR1', ''), file=sys.stderr)
+        print("TEST_VAR2 : " + os.getenv('TEST_VAR2', ''), file=sys.stderr)
         self.assertTrue(os.getenv('TEST_VAR1', '') == 'true')
         self.assertTrue(os.getenv('TEST_VAR2', '') == 'false')
 

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+import unittest
+import numpy
+
+class TestNumpy(unittest.TestCase):
+
+    def test_numpy(self):
+
+        print("NumPy : ", numpy.version.full_version)
+        print("Python: ", sys.version)
+        self.assertTrue('true')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+
 import sys
 import unittest
 import numpy
@@ -9,8 +11,8 @@ class TestNumpy(unittest.TestCase):
 
     def test_numpy(self):
 
-        print("NumPy : ", numpy.version.full_version)
-        print("Python: ", sys.version)
+        print("NumPy : " + numpy.version.full_version, file=sys.stderr)
+        print("Python: " + sys.version, file=sys.stderr)
         self.assertTrue('true')
 
 if __name__ == '__main__':

--- a/test/test_scipy.py
+++ b/test/test_scipy.py
@@ -5,13 +5,13 @@ from __future__ import print_function
 
 import sys
 import unittest
-import numpy
+import scipy
 
 class TestNumpy(unittest.TestCase):
 
     def test_numpy(self):
 
-        print("NumPy : " + numpy.version.full_version, file=sys.stderr)
+        print("NumPy : " + scipy.version.full_version, file=sys.stderr)
         print("Python: " + sys.version, file=sys.stderr)
         self.assertTrue('true')
 

--- a/travis.sh
+++ b/travis.sh
@@ -146,6 +146,8 @@ if [ "$USE_DOCKER" = true ]; then
     --env-file $DOCKER_ENV_FILE \
     -t $DOCKER_IMAGE bash -c 'cd $CI_SOURCE_PATH; .travis/docker.sh'
   DOCKER_EXIT_CODE=$?
+
+  travis_time_start show_cache
   rm $DOCKER_ENV_FILE
   sudo chown -R travis.travis $HOME/apt-cacher-ng
   # sudo tail -n 100 /var/log/apt-cacher-ng/*
@@ -154,6 +156,7 @@ if [ "$USE_DOCKER" = true ]; then
   sudo chown -R travis.travis $HOME
   # find $HOME/.ccache    -type f
   find $HOME/.cache/pip -type f | grep whl || echo "OK"
+  travis_time_end
   set +x
   return $DOCKER_EXIT_CODE
 fi
@@ -418,6 +421,10 @@ else
   #travis_wait 60 catkin run_tests -i --no-deps --no-status $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS $CMAKE_ARGS_FLAGS --
   travis_wait 60 catkin build --catkin-make-args run_tests -- -i --no-deps --no-status $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS $CMAKE_ARGS_FLAGS --
 fi
+
+travis_time_end
+travis_time_start catkin_test_results
+
 catkin_test_results --verbose --all build || error
 
 travis_time_end


### PR DESCRIPTION
- use `rosdep-install.sh` for indigo users
 c.f.: we used this script when `rosbuild`->`catkin` transition period, that catkin works incorrectly with old `manifest.xml` package. Now we use `rosdep-install.sh`, or users may manually install `python-*` codes.
- add travis_time_{start/end} around catkin_test_results/show cache