### PR TITLE
use git protocol.version 1

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -263,6 +263,9 @@ rosdep update --include-eol-distros|| while [ $ret != 0 ]; do sleep 1; rosdep up
 travis_time_end
 travis_time_start setup_catkin
 
+# avoid git protocol version error on travis
+git config --global --add protocol.version 1
+
 ### before_install: # Use this to prepare the system to install prerequisites or dependencies
 if [ "$ROS_DISTRO" == "hydro" ]; then
   [ ! -e /tmp/catkin ] && (cd /tmp/; git clone -q https://github.com/ros/catkin)


### PR DESCRIPTION
I face git version protocol error.
In order to avoid this, I set to use protocol version 2.
https://travis-ci.org/github/knorth55/ros_chainercv/jobs/723781730

```log
++ wstool init

Writing /home/travis/ros/ws_ros_chainercv/src/.rosinstall

update complete.

++ '[' false == false ']'

++ '[' -e /home/travis/build/knorth55/ros_chainercv/.travis.rosinstall ']'

++ '[' -e /home/travis/build/knorth55/ros_chainercv/.travis.rosinstall.melodic ']'

++ wstool merge --merge-replace -y file:///home/travis/build/knorth55/ros_chainercv/.travis.rosinstall.melodic

     Performing actions: 

     Add new elements:

  jsk_common   	git  https://github.com/jsk-ros-pkg/jsk_common.git   2.2.11

 vision_opencv   	git  https://github.com/ros-perception/vision_opencv.git   melodic

Config changed, maybe you need run wstool update to update SCM entries.

Overwriting /home/travis/ros/ws_ros_chainercv/src/.rosinstall

update complete.

++ wstool update

[jsk_common] Fetching https://github.com/jsk-ros-pkg/jsk_common.git (version 2.2.11) to /home/travis/ros/ws_ros_chainercv/src/jsk_common

Cloning into '/home/travis/ros/ws_ros_chainercv/src/jsk_common'...

fatal: unknown value for config 'protocol.version': 2

[vision_opencv] Fetching https://github.com/ros-perception/vision_opencv.git (version melodic) to /home/travis/ros/ws_ros_chainercv/src/vision_opencv

Cloning into '/home/travis/ros/ws_ros_chainercv/src/vision_opencv'...

fatal: unknown value for config 'protocol.version': 2

Exception caught during install: Error processing 'jsk_common' : [jsk_common] Checkout of https://github.com/jsk-ros-pkg/jsk_common.git version 2.2.11 into /home/travis/ros/ws_ros_chainercv/src/jsk_common failed.

Error processing 'vision_opencv' : [vision_opencv] Checkout of https://github.com/ros-perception/vision_opencv.git version melodic into /home/travis/ros/ws_ros_chainercv/src/vision_opencv failed.

ERROR in config: Error processing 'jsk_common' : [jsk_common] Checkout of https://github.com/jsk-ros-pkg/jsk_common.git version 2.2.11 into /home/travis/ros/ws_ros_chainercv/src/jsk_common failed.

Error processing 'vision_opencv' : [vision_opencv] Checkout of https://github.com/ros-perception/vision_opencv.git version melodic into /home/travis/ros/ws_ros_chainercv/src/vision_opencv failed.

+++ error

```