### PR TITLE
fix last release 0.5.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ before_script:
   - find $HOME/.cache/pip -type f
   - export ROSDEP_ADDITIONAL_OPTIONS='-n -v --ignore-src' # run rosdep without -q, -r and -v
   - if [ ${ROS_DISTRO} == "noetic" ]; then export BEFORE_SCRIPT="sed -ie \"/gazebo/ d\" \${CI_SOURCE_PATH}/package.xml;${BEFORE_SCRIPT}"; fi # FIXME gazebo is not released in noetic
-  - mkdir .travis; cp -r * .travis # need to copy, since directory starting from . is ignoreed by catkin build
+  - mkdir .travis; mv *.sh *.py *.conf .travis/ # need to move, since directory starting from . is ignoreed by catkin build
   - export BEFORE_SCRIPT="rm -fr jsk_travis/CATKIN_IGNORE; git clone https://github.com/ros/ros_tutorials -b ${ROS_DISTRO}-devel;${BEFORE_SCRIPT}"
   - if [ "${USE_CATKIN_MAKE}" == "true" ] ;then sed -i 's@catkin build -i -v --limit-status-rate 0.001@catkin_make@' .travis/travis.sh; fi
   - if [ "${USE_CATKIN_MAKE}" == "true" ] ;then sed -i 's@catkin run_tests --no-deps --limit-status-rate 0.001@catkin_make run_tests@' .travis/travis.sh; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,5 +16,7 @@ if(ENABLE_TEST_GAZEBO)
   add_rostest(test/gazebo.test)
 endif()
 
-install(FILES rosdep-install.sh travis_jenkins.py travis.sh
+file(GLOB_RECURSE script_files RELATIVE ${PROJECT_SOURCE_DIR} *.sh *.py)
+message(STATUS "install ${script_files}")
+install(FILES ${script_files}
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/docker.sh
+++ b/docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. travis_utils.sh
+. $(dirname "${BASH_SOURCE[0]}")/travis_utils.sh
 
 travis_time_start setup_docker
 

--- a/travis.sh
+++ b/travis.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. travis_utils.sh
+. $(dirname "${BASH_SOURCE[0]}")/travis_utils.sh
 
 echo "Running jsk_travis/travis.sh whose version is $(cd .travis && git describe --all)."
 


### PR DESCRIPTION
see https://api.travis-ci.org/v3/job/729812042/log.txt for example

```
.travis/travis.sh: line 3: travis_utils.sh: No such file or directory
Running jsk_travis/travis.sh whose version is tags/0.5.15.
.travis/travis.sh: line 7: travis_time_start: command not found
.travis/travis.sh: line 18: travis_time_end: command not found
.travis/travis.sh: line 19: travis_time_start: command not found
INFO: jsk_travis is successfully upgraded comparing the version commited to origin/master.
It is 3 commits ahead.
.travis/travis.sh: line 45
```

mv all scripts into .travis and run tests