### PR TITLE
use 2.7 get-pip.py to install pip 20.3.4 to run  on python2.7

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -14,7 +14,7 @@ fi
 sudo -E apt-get -y -qq update
 sudo -E apt-get -y -qq install apt-utils build-essential curl git lsb-release wget
 # 20.04 does not have pip, so install get-pip.py
-sudo -E apt-get -y -qq install python-pip python-setuptools || (sudo -E apt-get -y -qq install python; curl https://bootstrap.pypa.io/get-pip.py | sudo -E python; sudo -E apt-get -y -qq install python3-pip)
+sudo -E apt-get -y -qq install python-pip python-setuptools || (sudo -E apt-get -y -qq install python; curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo -E python; sudo -E apt-get -y -qq install python3-pip)
 
 # add user for testing
 adduser --disabled-password --gecos "" travis

--- a/docker/Dockerfile.ros-ubuntu:14.04-pcl
+++ b/docker/Dockerfile.ros-ubuntu:14.04-pcl
@@ -15,7 +15,7 @@ RUN rosdep resolve python-h5py | sed -e "s/^#.*//g" | xargs sudo apt-get install
 RUN sudo apt-get install -y octave festival
 
 # fix latest pip install fcn errors
-RUN curl https://bootstrap.pypa.io/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
+RUN curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
 RUN sudo apt install -y python-tornado # pip installed tornado (5.1.1) fails on 14.04
 RUN sudo pip install fcn chainercv chainer==6.7.0 cupy-cuda91
 

--- a/docker/Dockerfile.ros-ubuntu:14.04-pcl1.8
+++ b/docker/Dockerfile.ros-ubuntu:14.04-pcl1.8
@@ -44,7 +44,7 @@ RUN rosdep resolve python-h5py | sed -e "s/^#.*//g" | xargs sudo apt-get install
 RUN sudo apt-get install -y octave festival
 
 # fix latest pip install fcn errors
-RUN curl https://bootstrap.pypa.io/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
+RUN curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
 RUN sudo apt install -y python-tornado # pip installed tornado (5.1.1) fails on 14.04
 RUN sudo pip install fcn chainercv chainer==6.7.0 cupy-cuda91
 

--- a/docker/Dockerfile.ros-ubuntu:16.04-pcl
+++ b/docker/Dockerfile.ros-ubuntu:16.04-pcl
@@ -10,7 +10,7 @@ RUN rosdep resolve gtk2 | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # i
 RUN rosdep resolve python-qt-bindings | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # qt_gui_core
 
 # fix latest pip install fcn errors
-RUN curl https://bootstrap.pypa.io/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
+RUN curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
 RUN sudo pip install fcn chainercv chainer==6.7.0 cupy-cuda91
 
 # install common package to speedup

--- a/docker/Dockerfile.ros-ubuntu:18.04-pcl
+++ b/docker/Dockerfile.ros-ubuntu:18.04-pcl
@@ -10,7 +10,7 @@ RUN rosdep resolve gtk2 | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # i
 RUN rosdep resolve python-qt-bindings | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # qt_gui_core
 
 # fix latest pip install fcn errors
-RUN curl https://bootstrap.pypa.io/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
+RUN curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
 RUN sudo pip install fcn chainercv chainer==6.7.0 cupy-cuda91
 
 # install common package to speedup

--- a/docker/Dockerfile.ros-ubuntu:20.04-pcl
+++ b/docker/Dockerfile.ros-ubuntu:20.04-pcl
@@ -10,7 +10,7 @@ RUN rosdep resolve gtk2 | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # i
 # RUN rosdep resolve python-qt-bindings | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # qt_gui_core
 
 # fix latest pip install fcn errors
-RUN curl https://bootstrap.pypa.io/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
+RUN curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
 RUN sudo pip install fcn chainercv chainer==6.7.0 cupy-cuda91
 
 # install common package to speedup

--- a/travis.sh
+++ b/travis.sh
@@ -173,7 +173,7 @@ if [ ! "$ROSDEP_ADDITIONAL_OPTIONS" ]; then export ROSDEP_ADDITIONAL_OPTIONS="-n
 echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
 
 # Install pip
-curl https://bootstrap.pypa.io/get-pip.py | sudo python -
+curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python -
 # pip>=10 no longer uninstalls distutils packages (ex. packages installed via apt),
 # and fails to install packages via pip if they are already installed via apt.
 # See https://github.com/pypa/pip/issues/4805 for detail.


### PR DESCRIPTION
because pip 21.0 is released, which droped python 2.7 support in january 2021.
https://pip.pypa.io/en/latest/development/release-process/#python-2-support

with `https://bootstrap.pypa.io/2.7/get-pip.py`, we can install pip which supports python 2.7.