### PR TITLE
apt-get update and remove apt cache in every run step

### DIFF
--- a/docker/Dockerfile.ros-ubuntu:14.04-pcl
+++ b/docker/Dockerfile.ros-ubuntu:14.04-pcl
@@ -1,22 +1,56 @@
 FROM ros-ubuntu:14.04
 
-RUN sudo apt-get update
-RUN sudo apt-get install -y python-vtk tcl-vtk
-RUN sudo apt-get install -y ros-indigo-pcl-conversions ros-indigo-pcl-ros ros-indigo-octomap-server
-RUN sudo apt-get install -y ros-indigo-rviz ros-indigo-robot-self-filter ros-indigo-moveit-ros-perception
-RUN sudo apt-get install -y libopencv-dev liblapack-dev
-RUN sudo apt-get install -y emacs cython
-RUN rosdep update --include-eol-distros
-RUN rosdep resolve gtk2 | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # image_view
-RUN rosdep resolve python-qt-bindings | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # qt_gui_core
-RUN rosdep resolve libqt5-gui | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # libqt5-gui
-RUN rosdep resolve qt5-qmake | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # qt5-qmake
-RUN rosdep resolve python-h5py | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # python-h5py
-RUN sudo apt-get install -y octave festival
+RUN sudo apt-get update && \
+    sudo apt-get install -y python-vtk tcl-vtk && \
+    sudo rm -rf /var/lib/apt/lists/*
+RUN sudo apt-get update && \
+    sudo apt-get install -y ros-indigo-pcl-conversions ros-indigo-pcl-ros ros-indigo-octomap-server && \
+    sudo rm -rf /var/lib/apt/lists/*
+RUN sudo apt-get update && \
+    sudo apt-get install -y ros-indigo-rviz ros-indigo-robot-self-filter ros-indigo-moveit-ros-perception && \
+    sudo rm -rf /var/lib/apt/lists/*
+RUN sudo apt-get update && \
+    sudo apt-get install -y libopencv-dev liblapack-dev && \
+    sudo rm -rf /var/lib/apt/lists/*
+RUN sudo apt-get update && \
+    sudo apt-get install -y emacs cython && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+# image_view
+RUN sudo apt-get update && \
+    rosdep update --include-eol-distros && \
+    rosdep resolve gtk2 | sed -e "s/^#.*//g" | xargs sudo apt-get install -y  && \
+    sudo rm -rf /var/lib/apt/lists/*
+# qt_gui_core
+RUN sudo apt-get update && \
+    rosdep update --include-eol-distros && \
+    rosdep resolve python-qt-bindings | sed -e "s/^#.*//g" | xargs sudo apt-get install -y && \
+    sudo rm -rf /var/lib/apt/lists/*
+# libqt5-gui
+RUN sudo apt-get update && \
+    rosdep update --include-eol-distros && \
+    rosdep resolve libqt5-gui | sed -e "s/^#.*//g" | xargs sudo apt-get install -y && \
+    sudo rm -rf /var/lib/apt/lists/*
+# qt5-qmake
+RUN sudo apt-get update && \
+    rosdep update --include-eol-distros && \
+    rosdep resolve qt5-qmake | sed -e "s/^#.*//g" | xargs sudo apt-get install -y && \
+    sudo rm -rf /var/lib/apt/lists/*
+# python-h5py
+RUN sudo apt-get update && \
+    rosdep update --include-eol-distros && \
+    rosdep resolve python-h5py | sed -e "s/^#.*//g" | xargs sudo apt-get install -y && \
+    sudo rm -rf /var/lib/apt/lists/*
+RUN sudo apt-get update && \
+    sudo apt-get install -y octave festival && \
+    sudo rm -rf /var/lib/apt/lists/*
 
 # fix latest pip install fcn errors
 RUN curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
-RUN sudo apt install -y python-tornado # pip installed tornado (5.1.1) fails on 14.04
+# pip installed tornado (5.1.1) fails on 14.04
+RUN sudo apt-get update && \
+    sudo apt-get install -y python-tornado && \
+    sudo rm -rf /var/lib/apt/lists/*
 RUN sudo pip install fcn chainercv chainer==6.7.0 cupy-cuda91
 
 # install package to speedup

--- a/docker/Dockerfile.ros-ubuntu:14.04-pcl1.8
+++ b/docker/Dockerfile.ros-ubuntu:14.04-pcl1.8
@@ -13,47 +13,89 @@ RUN cd ~/pcl-pcl-1.8.0rc2 && \
 
 RUN mkdir -p ~/ros/ws_jsk_recognition/src && \
     cd ~/ros/ws_jsk_recognition/src && \
-    sudo apt-get install -y python-rosinstall-generator python-wstool && \
+    sudo apt-get update && \
+    sudo apt-get install -y python-rosinstall-generator python-wstool python-catkin-tools && \
     rosinstall_generator --tar --rosdistro indigo \
         pcl_conversions \
         pcl_ros \
         octomap_server \
         > .rosinstall && \
-    wstool up -j -1
+    wstool up -j -1 && \
+    sudo rm -rf /var/lib/apt/lists/*
 
 RUN cd ~/ros/ws_jsk_recognition/src && \
+    sudo apt-get update && \
     rosdep update --include-eol-distros && \
-    rosdep install --from-path . -y -i
+    rosdep install --from-path . -y -i && \
+    sudo rm -rf /var/lib/apt/lists/*
 
 RUN cd ~/ros/ws_jsk_recognition && \
-    sudo apt-get install -y python-catkin-tools && \
     . /opt/ros/indigo/setup.sh && \
     catkin build
 
-RUN sudo apt-get install -y python-vtk tcl-vtk
-RUN sudo apt-get install -y ros-indigo-pcl-conversions ros-indigo-pcl-ros ros-indigo-octomap-server
-RUN sudo apt-get install -y ros-indigo-rviz ros-indigo-robot-self-filter ros-indigo-moveit-ros-perception
-RUN sudo apt-get install -y libopencv-dev liblapack-dev
-RUN sudo apt-get install -y emacs cython
-RUN rosdep update --include-eol-distros
-RUN rosdep resolve gtk2 | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # image_view
-RUN rosdep resolve python-qt-bindings | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # qt_gui_core
-RUN rosdep resolve libqt5-gui | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # libqt5-gui
-RUN rosdep resolve qt5-qmake | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # qt5-qmake
-RUN rosdep resolve python-h5py | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # python-h5py
-RUN sudo apt-get install -y octave festival
+RUN sudo apt-get update && \
+    sudo apt-get install -y python-vtk tcl-vtk && \
+    sudo rm -rf /var/lib/apt/lists/*
+RUN sudo apt-get update && \
+    sudo apt-get install -y ros-indigo-pcl-conversions ros-indigo-pcl-ros ros-indigo-octomap-server && \
+    sudo rm -rf /var/lib/apt/lists/*
+RUN sudo apt-get update && \
+    sudo apt-get install -y ros-indigo-rviz ros-indigo-robot-self-filter ros-indigo-moveit-ros-perception && \
+    sudo rm -rf /var/lib/apt/lists/*
+RUN sudo apt-get update && \
+    sudo apt-get install -y libopencv-dev liblapack-dev && \
+    sudo rm -rf /var/lib/apt/lists/*
+RUN sudo apt-get update && \
+    sudo apt-get install -y emacs cython && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+# image_view
+RUN sudo apt-get update && \
+    rosdep update --include-eol-distros && \
+    rosdep resolve gtk2 | sed -e "s/^#.*//g" | xargs sudo apt-get install -y && \
+    sudo rm -rf /var/lib/apt/lists/*
+# qt_gui_core
+RUN sudo apt-get update && \
+    rosdep update --include-eol-distros && \
+    rosdep resolve python-qt-bindings | sed -e "s/^#.*//g" | xargs sudo apt-get install -y && \
+    sudo rm -rf /var/lib/apt/lists/*
+# libqt5-gui
+RUN sudo apt-get update && \
+    rosdep update --include-eol-distros && \
+    rosdep resolve libqt5-gui | sed -e "s/^#.*//g" | xargs sudo apt-get install -y && \
+    sudo rm -rf /var/lib/apt/lists/*
+# qt5-qmake
+RUN sudo apt-get update && \
+    rosdep update --include-eol-distros && \
+    rosdep resolve qt5-qmake | sed -e "s/^#.*//g" | xargs sudo apt-get install -y && \
+    sudo rm -rf /var/lib/apt/lists/*
+# python-h5py
+RUN sudo apt-get update && \
+    rosdep update --include-eol-distros && \
+    rosdep resolve python-h5py | sed -e "s/^#.*//g" | xargs sudo apt-get install -y && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+RUN sudo apt-get update && \
+    sudo apt-get install -y octave festival && \
+    sudo rm -rf /var/lib/apt/lists/*
+
 
 # fix latest pip install fcn errors
 RUN curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
-RUN sudo apt install -y python-tornado # pip installed tornado (5.1.1) fails on 14.04
+# pip installed tornado (5.1.1) fails on 14.04
+RUN sudo apt-get update && \
+    sudo apt-get install -y python-tornado && \
+    sudo rm -rf /var/lib/apt/lists/*
 RUN sudo pip install fcn chainercv chainer==6.7.0 cupy-cuda91
 
 # install common package to speedup
 RUN sudo pip install freezegun
-RUN sudo apt-get install -y libshiboken-dev shiboken \
+RUN sudo apt-get update && \
+    sudo apt-get install -y libshiboken-dev shiboken \
                                 python-qt4 python-qt4-dev python-sip-dev libvtk-java \
                                 libgtk2.0-dev \
                                 python-pyside libpyside-dev \
                                 ros-indigo-rqt-reconfigure python-matplotlib imagemagick \
                                 python-rosinstall-generator python-wstool \
-                                ros-indigo-pcl-msgs ros-indigo-octomap-msgs
+                                ros-indigo-pcl-msgs ros-indigo-octomap-msgs && \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.ros-ubuntu:16.04-pcl
+++ b/docker/Dockerfile.ros-ubuntu:16.04-pcl
@@ -1,28 +1,45 @@
 FROM ros-ubuntu:16.04
 
-RUN sudo apt-get update
-RUN sudo apt-get install -y ros-kinetic-pcl-conversions ros-kinetic-pcl-ros ros-kinetic-octomap-server
-RUN sudo apt-get install -y ros-kinetic-rviz ros-kinetic-robot-self-filter ros-kinetic-moveit-ros-perception
-RUN sudo apt-get install -y libopencv-dev liblapack-dev
-RUN sudo apt-get install -y emacs cython
-RUN rosdep update --include-eol-distros
-RUN rosdep resolve gtk2 | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # image_view
-RUN rosdep resolve python-qt-bindings | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # qt_gui_core
+RUN sudo apt-get update && \
+    sudo apt-get install -y ros-kinetic-pcl-conversions ros-kinetic-pcl-ros ros-kinetic-octomap-server && \
+    sudo rm -rf /var/lib/apt/lists/*
 
+RUN sudo apt-get update && \
+    sudo apt-get install -y ros-kinetic-rviz ros-kinetic-robot-self-filter ros-kinetic-moveit-ros-perception && \
+    sudo rm -rf /var/lib/apt/lists/*
+RUN sudo apt-get update && \
+    sudo apt-get install -y libopencv-dev liblapack-dev && \
+    sudo rm -rf /var/lib/apt/lists/*
+RUN sudo apt-get update && \
+    sudo apt-get install -y emacs cython && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+# image_view
+RUN sudo apt-get update && \
+    rosdep update --include-eol-distros && \
+    rosdep resolve gtk2 | sed -e "s/^#.*//g" | xargs sudo apt-get install -y && \
+    sudo rm -rf /var/lib/apt/lists/*
+# qt_gui_core
+RUN sudo apt-get update && \
+    rosdep update --include-eol-distros && \
+    rosdep resolve python-qt-bindings | sed -e "s/^#.*//g" | xargs sudo apt-get install -y && \
+    sudo rm -rf /var/lib/apt/lists/*
 # fix latest pip install fcn errors
 RUN curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
 RUN sudo pip install fcn chainercv chainer==6.7.0 cupy-cuda91
 
 # install common package to speedup
 RUN sudo pip install freezegun
-RUN sudo apt-get install -y libshiboken-dev shiboken \
+RUN sudo apt-get update && \
+    sudo apt-get install -y libshiboken-dev shiboken \
                                 python-qt4 python-qt4-dev python-sip-dev libvtk-java \
                                 libgtk2.0-dev \
                                 python-pyside libpyside-dev \
                                 ros-kinetic-rqt-reconfigure python-matplotlib imagemagick \
                                 python-rosinstall-generator python-wstool \
-                                ros-kinetic-pcl-msgs ros-kinetic-octomap-msgs
+                                ros-kinetic-pcl-msgs ros-kinetic-octomap-msgs && \
+    sudo rm -rf /var/lib/apt/lists/*
 
 ARG CACHEBUST=1
 RUN echo $CACHBUST
-RUN sudo apt-get update && sudo apt-get dist-upgrade -y
+RUN sudo apt-get update && sudo apt-get dist-upgrade -y && sudo rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.ros-ubuntu:18.04-pcl
+++ b/docker/Dockerfile.ros-ubuntu:18.04-pcl
@@ -1,13 +1,28 @@
 FROM ros-ubuntu:18.04
 
-RUN sudo apt-get update
-RUN sudo apt-get install -y ros-melodic-pcl-conversions ros-melodic-pcl-ros ros-melodic-octomap-server
-RUN sudo apt-get install -y ros-melodic-rviz ros-melodic-robot-self-filter ros-melodic-moveit-ros-perception
-RUN sudo apt-get install -y libopencv-dev liblapack-dev
-RUN sudo apt-get install -y emacs cython
-RUN rosdep update --include-eol-distros
-RUN rosdep resolve gtk2 | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # image_view
-RUN rosdep resolve python-qt-bindings | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # qt_gui_core
+RUN sudo apt-get update && \
+    sudo apt-get install -y ros-melodic-pcl-conversions ros-melodic-pcl-ros ros-melodic-octomap-server && \
+    sudo rm -rf /var/lib/apt/lists/*
+RUN sudo apt-get update && \
+    sudo apt-get install -y ros-melodic-rviz ros-melodic-robot-self-filter ros-melodic-moveit-ros-perception && \
+    sudo rm -rf /var/lib/apt/lists/*
+RUN sudo apt-get update && \
+    sudo apt-get install -y libopencv-dev liblapack-dev && \
+    sudo rm -rf /var/lib/apt/lists/*
+RUN sudo apt-get update && \
+    sudo apt-get install -y emacs cython && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+# image_view
+RUN sudo apt-get update && \
+    rosdep update --include-eol-distros && \
+    rosdep resolve gtk2 | sed -e "s/^#.*//g" | xargs sudo apt-get install -y && \
+    sudo rm -rf /var/lib/apt/lists/*
+# qt_gui_core
+RUN sudo apt-get update && \
+    rosdep update --include-eol-distros && \
+    rosdep resolve python-qt-bindings | sed -e "s/^#.*//g" | xargs sudo apt-get install -y && \
+    sudo rm -rf /var/lib/apt/lists/*
 
 # fix latest pip install fcn errors
 RUN curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
@@ -15,14 +30,16 @@ RUN sudo pip install fcn chainercv chainer==6.7.0 cupy-cuda91
 
 # install common package to speedup
 RUN sudo pip install freezegun
-RUN sudo apt-get install -y libshiboken-dev shiboken \
+RUN sudo apt-get update && \
+    sudo apt-get install -y libshiboken-dev shiboken \
                                 python-qt4 python-qt4-dev python-sip-dev \
                                 libgtk2.0-dev \
                                 python-pyside libpyside-dev \
                                 ros-melodic-rqt-reconfigure python-matplotlib imagemagick \
                                 python-rosinstall-generator python-wstool \
-                                ros-melodic-pcl-msgs ros-melodic-octomap-msgs
+                                ros-melodic-pcl-msgs ros-melodic-octomap-msgs && \
+    sudo rm -rf /var/lib/apt/lists/*
 
 ARG CACHEBUST=1
 RUN echo $CACHBUST
-RUN sudo apt-get update && sudo apt-get dist-upgrade -y
+RUN sudo apt-get update && sudo apt-get dist-upgrade -y && sudo rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.ros-ubuntu:20.04-pcl
+++ b/docker/Dockerfile.ros-ubuntu:20.04-pcl
@@ -1,12 +1,23 @@
 FROM ros-ubuntu:20.04
 
-RUN sudo apt-get update
-RUN sudo apt-get install -y ros-noetic-pcl-conversions ros-noetic-pcl-ros ros-noetic-octomap-server
-RUN sudo apt-get install -y ros-noetic-rviz ros-noetic-robot-self-filter ros-noetic-moveit-ros-perception
-RUN sudo apt-get install -y libopencv-dev liblapack-dev
-RUN sudo apt-get install -y emacs cython
-RUN rosdep update --include-eol-distros
-RUN rosdep resolve gtk2 | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # image_view
+RUN sudo apt-get update && \
+    sudo apt-get install -y ros-noetic-pcl-conversions ros-noetic-pcl-ros ros-noetic-octomap-server && \
+    sudo rm -rf /var/lib/apt/lists/*
+RUN sudo apt-get update && \
+    sudo apt-get install -y ros-noetic-rviz ros-noetic-robot-self-filter ros-noetic-moveit-ros-perception && \
+    sudo rm -rf /var/lib/apt/lists/*
+RUN sudo apt-get update && \
+    sudo apt-get install -y libopencv-dev liblapack-dev && \
+
+RUN sudo apt-get update && \
+    sudo apt-get install -y emacs cython && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+# image_view
+RUN sudo apt-get update && \
+    rosdep update --include-eol-distros && \
+    rosdep resolve gtk2 | sed -e "s/^#.*//g" | xargs sudo apt-get install -y && \
+    sudo rm -rf /var/lib/apt/lists/*
 # RUN rosdep resolve python-qt-bindings | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # qt_gui_core
 
 # fix latest pip install fcn errors
@@ -15,11 +26,13 @@ RUN sudo pip install fcn chainercv chainer==6.7.0 cupy-cuda91
 
 # install common package to speedup
 RUN sudo pip install freezegun
-RUN sudo apt-get install -y libshiboken2-dev shiboken2 \
+RUN sudo apt-get update && \
+    sudo apt-get install -y libshiboken2-dev shiboken2 \
                                 python3-pyside2.qtgui \
                                 ros-noetic-rqt-reconfigure python3-matplotlib imagemagick \
-                                ros-noetic-pcl-msgs ros-noetic-octomap-msgs
+                                ros-noetic-pcl-msgs ros-noetic-octomap-msgs && \
+    sudo rm -rf /var/lib/apt/lists/*
 
 ARG CACHEBUST=1
 RUN echo $CACHBUST
-RUN sudo apt-get update && sudo apt-get dist-upgrade -y
+RUN sudo apt-get update && sudo apt-get dist-upgrade -y && sudo rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
we need to apt-get update in every steps to get latest apt information.
we need to remove apt cache in every steps to make docker images lighter.

This PR fix the build error in https://travis-ci.com/github/jsk-ros-pkg/jsk_travis/jobs/475442128 and https://travis-ci.com/github/jsk-ros-pkg/jsk_travis/jobs/475442129.
These build errors were caused by `apt-get` problem in docker.
We need to do `apt-get update` in every step to get the latest apt information, otherwise build fails because of old apt information.

```
+ docker build -t ros-ubuntu:18.04-pcl --build-arg CACHEBUST=20210126 -f .travis/docker/Dockerfile.ros-ubuntu:18.04-pcl .travis/docker
Sending build context to Docker daemon  32.77kB
Step 1/16 : FROM ros-ubuntu:18.04
 ---> dea9c3fa1d89
Step 2/16 : RUN sudo apt-get update
 ---> Using cache
 ---> 4a95cab076ea
Step 3/16 : RUN sudo apt-get install -y ros-melodic-pcl-conversions ros-melodic-pcl-ros ros-melodic-octomap-server
 ---> Using cache
 ---> 070254552a2d
Step 4/16 : RUN sudo apt-get install -y ros-melodic-rviz ros-melodic-robot-self-filter ros-melodic-moveit-ros-perception
 ---> Using cache
 ---> 719e5afb56f4
Step 5/16 : RUN sudo apt-get install -y libopencv-dev liblapack-dev
 ---> Using cache
 ---> 29913d25e90a
Step 6/16 : RUN sudo apt-get install -y emacs cython
 ---> Using cache
 ---> 7f3d356d9c8e
Step 7/16 : RUN rosdep update --include-eol-distros
 ---> Using cache
 ---> 629dea774af6
Step 8/16 : RUN rosdep resolve gtk2 | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # image_view
 ---> Using cache
 ---> 00d2ac9169c1
Step 9/16 : RUN rosdep resolve python-qt-bindings | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # qt_gui_core
 ---> Using cache
 ---> c7067c5de6d3
Step 10/16 : RUN curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
 ---> Using cache
 ---> da03d49c5d08
Step 11/16 : RUN sudo pip install fcn chainercv chainer==6.7.0 cupy-cuda91
 ---> Using cache
 ---> ae9f26113fb5
Step 12/16 : RUN sudo pip install freezegun
 ---> Using cache
 ---> c4420486fa56
Step 13/16 : RUN sudo apt-get install -y libshiboken-dev shiboken                                 python-qt4 python-qt4-dev python-sip-dev                                 libgtk2.0-dev                                 python-pyside libpyside-dev                                 ros-melodic-rqt-reconfigure python-matplotlib imagemagick                                 python-rosinstall-generator python-wstool                                 ros-melodic-pcl-msgs ros-melodic-octomap-msgs
 ---> Running in 1b8e2a356b22
Reading package lists...
Building dependency tree...
Reading state information...
libgtk2.0-dev is already the newest version (2.24.32-1ubuntu1).
libpyside-dev is already the newest version (1.2.2+source1-3).
libshiboken-dev is already the newest version (1.2.2-5).
python-pyside is already the newest version (1.2.2+source1-3).
python-qt4 is already the newest version (4.12.1+dfsg-2).
python-qt4-dev is already the newest version (4.12.1+dfsg-2).
shiboken is already the newest version (1.2.2-5).
python-sip-dev is already the newest version (4.19.7+dfsg-1ubuntu0.1).
python-wstool is already the newest version (0.1.17-1).
python-wstool set to manually installed.
ros-melodic-octomap-msgs is already the newest version (0.3.5-1bionic.20200812.182233).
ros-melodic-octomap-msgs set to manually installed.
ros-melodic-pcl-msgs is already the newest version (0.2.0-0bionic.20200821.042113).
ros-melodic-pcl-msgs set to manually installed.
The following package was automatically installed and is no longer required:
  libllvm7
Use 'sudo apt autoremove' to remove it.
The following additional packages will be installed:
  blt fonts-lyx imagemagick-6.q16 libdjvulibre-text libdjvulibre21
  libjs-jquery-ui libmagickcore-6.q16-3-extra libnetpbm10 libwmf0.2-7 netpbm
  python-backports.functools-lru-cache python-cycler python-matplotlib-data
  python-subprocess32 python-tk python-tz ros-melodic-qt-gui
  ros-melodic-rqt-console ros-melodic-rqt-gui ros-melodic-rqt-gui-py
  ros-melodic-rqt-logger-level ros-melodic-rqt-py-common tango-icon-theme
  tk8.6-blt2.5 ttf-bitstream-vera
Suggested packages:
  blt-demo imagemagick-doc autotrace cups-bsd | lpr | lprng enscript ffmpeg
  gimp gnuplot grads hp2xx html2ps libwmf-bin mplayer povray radiance
  sane-utils texlive-base-bin transfig ufraw-batch xdg-utils
  libjs-jquery-ui-docs inkscape libjxr-tools libwmf0.2-7-gtk python-cycler-doc
  dvipng gir1.2-gtk-3.0 ipython python-cairocffi python-excelerator
  python-gobject python-matplotlib-doc python-scipy python-tornado
  python-traits texlive-extra-utils texlive-latex-extra ttf-staypuft tix
  python-tk-dbg gnome-icon-theme kdelibs-data
The following NEW packages will be installed:
  blt fonts-lyx imagemagick imagemagick-6.q16 libdjvulibre-text libdjvulibre21
  libjs-jquery-ui libmagickcore-6.q16-3-extra libnetpbm10 libwmf0.2-7 netpbm
  python-backports.functools-lru-cache python-cycler python-matplotlib
  python-matplotlib-data python-rosinstall-generator python-subprocess32
  python-tk python-tz ros-melodic-qt-gui ros-melodic-rqt-console
  ros-melodic-rqt-gui ros-melodic-rqt-gui-py ros-melodic-rqt-logger-level
  ros-melodic-rqt-py-common ros-melodic-rqt-reconfigure tango-icon-theme
  tk8.6-blt2.5 ttf-bitstream-vera
0 upgraded, 29 newly installed, 0 to remove and 0 not upgraded.
Need to get 13.0 MB of archives.
After this operation, 50.0 MB of additional disk space will be used.
Get:1 http://packages.ros.org/ros/ubuntu bionic/main amd64 python-rosinstall-generator all 0.1.22-1 [11.5 kB]
Err:2 http://packages.ros.org/ros/ubuntu bionic/main amd64 ros-melodic-qt-gui amd64 0.4.2-1bionic.20200812.224151
  404  Not Found [IP: 64.50.233.100 80]
Err:3 http://packages.ros.org/ros/ubuntu bionic/main amd64 ros-melodic-rqt-gui amd64 0.5.2-1bionic.20200820.215543
  404  Not Found [IP: 64.50.233.100 80]
Err:4 http://packages.ros.org/ros/ubuntu bionic/main amd64 ros-melodic-rqt-gui-py amd64 0.5.2-1bionic.20200820.224424
  404  Not Found [IP: 64.50.233.100 80]
Err:5 http://packages.ros.org/ros/ubuntu bionic/main amd64 ros-melodic-rqt-logger-level amd64 0.4.8-0bionic.20200820.231044
  404  Not Found [IP: 64.50.233.100 80]
Err:6 http://packages.ros.org/ros/ubuntu bionic/main amd64 ros-melodic-rqt-py-common amd64 0.5.2-1bionic.20200821.170927
  404  Not Found [IP: 64.50.233.100 80]
Err:7 http://packages.ros.org/ros/ubuntu bionic/main amd64 ros-melodic-rqt-console amd64 0.4.9-1bionic.20200821.174747
  404  Not Found [IP: 64.50.233.100 80]
Err:8 http://packages.ros.org/ros/ubuntu bionic/main amd64 ros-melodic-rqt-reconfigure amd64 0.5.3-1bionic.20200821.175941
  404  Not Found [IP: 64.50.233.100 80]
Get:9 http://archive.ubuntu.com/ubuntu bionic/main amd64 tk8.6-blt2.5 amd64 2.5.3+dfsg-4 [572 kB]
Get:10 http://archive.ubuntu.com/ubuntu bionic/main amd64 blt amd64 2.5.3+dfsg-4 [4944 B]
Get:11 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 fonts-lyx all 2.2.4-0ubuntu0.18.04.1 [155 kB]
Ign:12 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 imagemagick-6.q16 amd64 8:6.9.7.4+dfsg-16ubuntu6.8
Ign:13 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 imagemagick amd64 8:6.9.7.4+dfsg-16ubuntu6.8
Get:14 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libdjvulibre-text all 3.5.27.1-8ubuntu0.2 [49.3 kB]
Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libdjvulibre21 amd64 3.5.27.1-8ubuntu0.2 [560 kB]
Get:16 http://archive.ubuntu.com/ubuntu bionic/universe amd64 libjs-jquery-ui all 1.12.1+dfsg-5 [232 kB]
Get:17 http://archive.ubuntu.com/ubuntu bionic/main amd64 libwmf0.2-7 amd64 0.2.8.4-12 [150 kB]
Ign:18 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libmagickcore-6.q16-3-extra amd64 8:6.9.7.4+dfsg-16ubuntu6.8
Get:19 http://archive.ubuntu.com/ubuntu bionic/main amd64 libnetpbm10 amd64 2:10.0-15.3build1 [58.0 kB]
Get:20 http://archive.ubuntu.com/ubuntu bionic/main amd64 netpbm amd64 2:10.0-15.3build1 [1017 kB]
Err:12 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 imagemagick-6.q16 amd64 8:6.9.7.4+dfsg-16ubuntu6.8
  404  Not Found [IP: 91.189.88.152 80]
Err:13 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 imagemagick amd64 8:6.9.7.4+dfsg-16ubuntu6.8
  404  Not Found [IP: 91.189.88.152 80]
Err:18 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 libmagickcore-6.q16-3-extra amd64 8:6.9.7.4+dfsg-16ubuntu6.8
  404  Not Found [IP: 91.189.88.152 80]
Get:21 http://archive.ubuntu.com/ubuntu bionic/universe amd64 python-backports.functools-lru-cache all 1.4-2 [5960 B]
Get:22 http://archive.ubuntu.com/ubuntu bionic/universe amd64 python-cycler all 0.10.0-1 [7520 B]
Get:23 http://archive.ubuntu.com/ubuntu bionic/universe amd64 ttf-bitstream-vera all 1.10-8 [352 kB]
Get:24 http://archive.ubuntu.com/ubuntu bionic/universe amd64 python-matplotlib-data all 2.1.1-2ubuntu3 [3774 kB]
Get:25 http://archive.ubuntu.com/ubuntu bionic/main amd64 python-tz all 2018.3-2 [31.6 kB]
Get:26 http://archive.ubuntu.com/ubuntu bionic/universe amd64 python-subprocess32 amd64 3.2.7-3 [27.2 kB]
Get:27 http://archive.ubuntu.com/ubuntu bionic/universe amd64 python-matplotlib amd64 2.1.1-2ubuntu3 [3901 kB]
Get:28 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 python-tk amd64 2.7.17-1~18.04 [26.0 kB]
Get:29 http://archive.ubuntu.com/ubuntu bionic/universe amd64 tango-icon-theme all 0.8.90-7 [1161 kB]
Fetched 12.1 MB in 20s (611 kB/s)
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/i/imagemagick/imagemagick-6.q16_6.9.7.4+dfsg-16ubuntu6.8_amd64.deb  404  Not Found [IP: 91.189.88.152 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/i/imagemagick/imagemagick_6.9.7.4+dfsg-16ubuntu6.8_amd64.deb  404  Not Found [IP: 91.189.88.152 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/i/imagemagick/libmagickcore-6.q16-3-extra_6.9.7.4+dfsg-16ubuntu6.8_amd64.deb  404  Not Found [IP: 91.189.88.152 80]
E: Failed to fetch http://packages.ros.org/ros/ubuntu/pool/main/r/ros-melodic-qt-gui/ros-melodic-qt-gui_0.4.2-1bionic.20200812.224151_amd64.deb  404  Not Found [IP: 64.50.233.100 80]
E: Failed to fetch http://packages.ros.org/ros/ubuntu/pool/main/r/ros-melodic-rqt-gui/ros-melodic-rqt-gui_0.5.2-1bionic.20200820.215543_amd64.deb  404  Not Found [IP: 64.50.233.100 80]
E: Failed to fetch http://packages.ros.org/ros/ubuntu/pool/main/r/ros-melodic-rqt-gui-py/ros-melodic-rqt-gui-py_0.5.2-1bionic.20200820.224424_amd64.deb  404  Not Found [IP: 64.50.233.100 80]
E: Failed to fetch http://packages.ros.org/ros/ubuntu/pool/main/r/ros-melodic-rqt-logger-level/ros-melodic-rqt-logger-level_0.4.8-0bionic.20200820.231044_amd64.deb  404  Not Found [IP: 64.50.233.100 80]
E: Failed to fetch http://packages.ros.org/ros/ubuntu/pool/main/r/ros-melodic-rqt-py-common/ros-melodic-rqt-py-common_0.5.2-1bionic.20200821.170927_amd64.deb  404  Not Found [IP: 64.50.233.100 80]
E: Failed to fetch http://packages.ros.org/ros/ubuntu/pool/main/r/ros-melodic-rqt-console/ros-melodic-rqt-console_0.4.9-1bionic.20200821.174747_amd64.deb  404  Not Found [IP: 64.50.233.100 80]
E: Failed to fetch http://packages.ros.org/ros/ubuntu/pool/main/r/ros-melodic-rqt-reconfigure/ros-melodic-rqt-reconfigure_0.5.3-1bionic.20200821.175941_amd64.deb  404  Not Found [IP: 64.50.233.100 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
The command '/bin/sh -c sudo apt-get install -y libshiboken-dev shiboken                                 python-qt4 python-qt4-dev python-sip-dev                                 libgtk2.0-dev                                 python-pyside libpyside-dev                                 ros-melodic-rqt-reconfigure python-matplotlib imagemagick                                 python-rosinstall-generator python-wstool                                 ros-melodic-pcl-msgs ros-melodic-octomap-msgs' returned a non-zero code: 100
+ set +x
```