### PR TITLE
update 2.7/get-pip.py url

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -14,7 +14,7 @@ fi
 sudo -E apt-get -y -qq update
 sudo -E apt-get -y -qq install apt-utils build-essential curl git lsb-release wget
 # 20.04 does not have pip, so install get-pip.py
-sudo -E apt-get -y -qq install python-pip python-setuptools || (sudo -E apt-get -y -qq install python; curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo -E python; sudo -E apt-get -y -qq install python3-pip)
+sudo -E apt-get -y -qq install python-pip python-setuptools || (sudo -E apt-get -y -qq install python; curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | sudo -E python; sudo -E apt-get -y -qq install python3-pip)
 
 # add user for testing
 adduser --disabled-password --gecos "" travis

--- a/docker/Dockerfile.ros-ubuntu:14.04-pcl
+++ b/docker/Dockerfile.ros-ubuntu:14.04-pcl
@@ -15,7 +15,7 @@ RUN rosdep resolve python-h5py | sed -e "s/^#.*//g" | xargs sudo apt-get install
 RUN sudo apt-get install -y octave festival
 
 # fix latest pip install fcn errors
-RUN curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
 RUN sudo apt install -y python-tornado # pip installed tornado (5.1.1) fails on 14.04
 RUN sudo pip install fcn chainercv chainer==6.7.0 cupy-cuda91
 

--- a/docker/Dockerfile.ros-ubuntu:14.04-pcl1.8
+++ b/docker/Dockerfile.ros-ubuntu:14.04-pcl1.8
@@ -44,7 +44,7 @@ RUN rosdep resolve python-h5py | sed -e "s/^#.*//g" | xargs sudo apt-get install
 RUN sudo apt-get install -y octave festival
 
 # fix latest pip install fcn errors
-RUN curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
 RUN sudo apt install -y python-tornado # pip installed tornado (5.1.1) fails on 14.04
 RUN sudo pip install fcn chainercv chainer==6.7.0 cupy-cuda91
 

--- a/docker/Dockerfile.ros-ubuntu:16.04-pcl
+++ b/docker/Dockerfile.ros-ubuntu:16.04-pcl
@@ -10,7 +10,7 @@ RUN rosdep resolve gtk2 | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # i
 RUN rosdep resolve python-qt-bindings | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # qt_gui_core
 
 # fix latest pip install fcn errors
-RUN curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
 RUN sudo pip install fcn chainercv chainer==6.7.0 cupy-cuda91
 
 # install common package to speedup

--- a/docker/Dockerfile.ros-ubuntu:18.04-pcl
+++ b/docker/Dockerfile.ros-ubuntu:18.04-pcl
@@ -10,7 +10,7 @@ RUN rosdep resolve gtk2 | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # i
 RUN rosdep resolve python-qt-bindings | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # qt_gui_core
 
 # fix latest pip install fcn errors
-RUN curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
 RUN sudo pip install fcn chainercv chainer==6.7.0 cupy-cuda91
 
 # install common package to speedup

--- a/docker/Dockerfile.ros-ubuntu:20.04-pcl
+++ b/docker/Dockerfile.ros-ubuntu:20.04-pcl
@@ -10,7 +10,7 @@ RUN rosdep resolve gtk2 | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # i
 # RUN rosdep resolve python-qt-bindings | sed -e "s/^#.*//g" | xargs sudo apt-get install -y # qt_gui_core
 
 # fix latest pip install fcn errors
-RUN curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | sudo python -; sudo -H pip install 'pip<10'
 RUN sudo pip install fcn chainercv chainer==6.7.0 cupy-cuda91
 
 # install common package to speedup

--- a/travis.sh
+++ b/travis.sh
@@ -173,7 +173,7 @@ if [ ! "$ROSDEP_ADDITIONAL_OPTIONS" ]; then export ROSDEP_ADDITIONAL_OPTIONS="-n
 echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
 
 # Install pip
-curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python -
+curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | sudo python -
 # pip>=10 no longer uninstalls distutils packages (ex. packages installed via apt),
 # and fails to install packages via pip if they are already installed via apt.
 # See https://github.com/pypa/pip/issues/4805 for detail.


### PR DESCRIPTION
fix "can not find get-pip.py" error 

```
+curl https://bootstrap.pypa.io/2.7/get-pip.py
+sudo python -
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   936  100   936    0     0  11036      0 --:--:-- --:--:-- --:--:-- 11142
Hi there!
The URL you are using to fetch this script has changed, and this one will no
longer work. Please use get-pip.py from the following URL instead:
    https://bootstrap.pypa.io/pip/2.7/get-pip.py
Sorry if this change causes any inconvenience for you!
We don't have a good mechanism to make more gradual changes here, and this
renaming is a part of an effort to make it easier to us to update these
scripts, when there's a pip release. It's also essential for improving how we
handle the `get-pip.py` scripts, when pip drops support for a Python minor
version.
There are no more renames/URL changes planned, and we don't expect that a need
would arise to do this again in the near future.
Thanks for understanding!
- Pradyun, on behalf of the volunteers who maintain pip.
```