### PR TITLE
enable to run github actions, until travis back

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,202 @@
+# jsk_travis
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - build: jenkins_hydro
+            USE_JENKINS: true
+            ROS_DISTRO : hydro
+          - build: jenkins_indigo
+            USE_JENKINS: true
+            ROS_DISTRO : indigo
+          - build: jenkins_kinetic
+            USE_JENKINS: true
+            ROS_DISTRO : kinetic
+          - build: jenkins_kinetic_pcl
+            USE_JENKINS: true
+            ROS_DISTRO : kinetic
+            DOCKER_IMAGE_JENKINS : ros-ubuntu:16.04-pcl
+          - build: jenkins_melodic
+            USE_JENKINS: true
+            ROS_DISTRO : melodic
+          - build: jenkins_melodic_pcl
+            USE_JENKINS: true
+            ROS_DISTRO : melodic
+            DOCKER_IMAGE_JENKINS : ros-ubuntu:18.04-pcl
+          - build: jenkins_noetic
+            USE_JENKINS: true
+            ROS_DISTRO : noetic
+          - build: jenkins_noetic_pcl
+            USE_JENKINS: true
+            ROS_DISTRO : noetic
+            DOCKER_IMAGE_JENKINS : ros-ubuntu:20.04-pcl
+          - build: hydro
+            container: ubuntu:12.04
+            ROS_DISTRO : hydro
+          - build: indigo
+            container: ubuntu:14.04
+            ROS_DISTRO : indigo
+          - build: kinetic
+            container: ubuntu:16.04
+            ROS_DISTRO : kinetic
+          - build: melodic
+            container: ubuntu:18.04
+            ROS_DISTRO : melodic
+          - build: melodic_catkin_make
+            container : ubuntu:18.04
+            ROS_DISTRO : melodic
+            USE_CATKIN_MAKE : true
+            BEFORE_SCRIPT : "pwd; git clone http://github.com/jsk-ros-pkg/jsk_common_msgs"
+            NOT_TEST_INSTALL : true
+          - build: melodic_test_packages
+            container : ubuntu:18.04
+            ROS_DISTRO : melodic
+            TEST_PKGS : ""
+          - build: melodic_repository_path
+            container : ubuntu:18.04
+            ROS_DISTRO : melodic
+            ROS_REPOSITORY_PATH : http://packages.ros.org/ros/ubuntu
+          - build: noetic
+            container: ubuntu:20.04
+            ROS_DISTRO : noetic
+          - build: noetic_python2
+            container: ubuntu:20.04
+            ROS_DISTRO : noetic
+            ROS_PYTHON_VERSION : 2
+            ROSDEP_ADDITIONAL_OPTIONS : "-n -q -r --ignore-src"
+            BEFORE_SCRIPT : "sudo pip install empy"
+            TEST_PKGS : "rospy_tutorials"
+          - build: noetic_python3
+            container: ubuntu:20.04
+            ROS_DISTRO : noetic
+            ROS_PYTHON_VERSION : 3
+          - build: check_python3
+            container: ubuntu:20.04
+
+    env:
+      CI_SOURCE_PATH: ${{ github.workspace }}
+      ADDITIONAL_ENV_TO_DOCKER : ${{ matrix.ADDITIONAL_ENV_TO_DOCKER }}
+      BEFORE_SCRIPT : ${{ matrix.BEFORE_SCRIPT }}
+      BUILDER : ${{ matrix.BUILDER }}
+      BUILD_PKGS : ${{ matrix.BUILD_PKGS }}
+      CATKIN_PARALLEL_JOBS : ${{ matrix.CATKIN_PARALLEL_JOBS }}
+      CATKIN_PARALLEL_TEST_JOBS : ${{ matrix.CATKIN_PARALLEL_TEST_JOBS }}
+      CATKIN_TOOLS_BUILD_OPTIONS : ${{ matrix.CATKIN_TOOLS_BUILD_OPTIONS }}
+      CATKIN_TOOLS_CONFIG_OPTIONS : ${{ matrix.CATKIN_TOOLS_CONFIG_OPTIONS }}
+      CMAKE_DEVELOPER_ERROR : ${{ matrix.CMAKE_DEVELOPER_ERROR }}
+      DEBUG_TRAVIS_PYTHON : ${{ matrix.DEBUG_TRAVIS_PYTHON }}
+      DOCKER_IMAGE_JENKINS : ${{ matrix.DOCKER_IMAGE_JENKINS }}
+      EXTRA_DEB : ${{ matrix.EXTRA_DEB }}
+      NOT_TEST_INSTALL : ${{ matrix.NOT_TEST_INSTALL }}
+      ROSDEP_ADDITIONAL_OPTIONS : ${{ matrix.ROSDEP_ADDITIONAL_OPTIONS || '-n -v --ignore-src' }}  # run rosdep without -q, -r and -v
+      ROSDEP_UPDATE_QUIET : ${{ matrix.ROSDEP_UPDATE_QUIET }}
+      ROSWS : ${{ matrix.ROSWS }}
+      ROS_DISTRO : ${{ matrix.ROS_DISTRO }}
+      ROS_LOG_DIR : ${{ matrix.ROS_LOG_DIR }}
+      ROS_PARALLEL_JOBS : ${{ matrix.ROS_PARALLEL_JOBS }}
+      ROS_PARALLEL_TEST_JOBS : ${{ matrix.ROS_PARALLEL_TEST_JOBS }}
+      ROS_PYTHON_VERSION : ${{ matrix.ROS_PYTHON_VERSION || '' }}
+      ROS_REPOSITORY_PATH : ${{ matrix.ROS_REPOSITORY_PATH }}
+      SUDO_PIP : ${{ matrix.SUDO_PIP }}
+      TARGET_PKGS : ${{ matrix.TARGET_PKGS }}
+      TEST_PKGS : ${{ matrix.TEST_PKGS }}
+      USE_CATKIN_MAKE : ${{ matrix.USE_CATKIN_MAKE }}
+      USE_DEB : ${{ matrix.USE_DEB }}
+      USE_JENKINS : ${{ matrix.USE_JENKINS || 'false' }}
+      USE_PYTHON_VIRTUALENV : ${{ matrix.USE_PYTHON_VIRTUALENV }}
+      USE_TRAVIS : ${{ matrix.USE_JENKINS == true && 'false' || 'true' }} # if not use_jenkins, use travis(actions)
+
+    name: ${{ matrix.ROS_DISTRO || matrix.build }}${{ matrix.USE_JENKINS && '+jenkins' || '' }}${{ matrix.ROS_PYTHON_VERSION == '2' && '+python2' || '' }}${{ matrix.ROS_PYTHON_VERSION == '3' && '+python3' || '' }}${{ matrix.ROS_REPOSITORY_PATH }}${{ matrix.BEFORE_SCRIPT && toJSON(matrix.BEFORE_SCRIPT) || '' }}${{ matrix.TARGET_PKGS && toJSON(matrix.TARGET_PKGS) || '' }}${{ matrix.TEST_PKGS && toJSON(matrix.TEST_PKGS) || '' }}${{ matrix.DOCKER_IMAGE_JENKINS && toJSON(matrix.DOCKER_IMAGE_JENKINS) || '' }}
+
+    container: ${{ matrix.container || 'ubuntu:18.04' }}
+
+    steps:
+      - name: Chcekout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+        if: ${{ ! ( matrix.ROS_DISTRO == 'hydro' &&  matrix.USE_JENKINS != 'true' ) }}
+      - name: Chcekout # hydro container does not work with actions/checkout@v2
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 2
+        if: ${{ matrix.ROS_DISTRO == 'hydro' &&  matrix.USE_JENKINS != 'true' }}
+      - name: Install system commands
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get -y -qq update
+          apt-get -y -qq install sudo
+          # install fundamental packages
+          sudo -E apt-get -y -qq update
+          sudo -E apt-get -y -qq install apt-utils build-essential curl git lsb-release wget
+          # 20.04 does not have pip, so install get-pip.py
+          sudo -E apt-get -y -qq install python-pip python-setuptools || (sudo -E apt-get -y -qq install python; curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | sudo -E python; sudo -E apt-get -y -qq install python3-pip)
+      - name: Run jsk_travis test
+        if: matrix.ROS_DISTRO != ''
+        run: |
+          set -x
+          # unset if  not defined
+          if [[ "${ADDITIONAL_ENV_TO_DOCKER}" == "" ]]; then unset ADDITIONAL_ENV_TO_DOCKER; fi
+          if [[ "${BEFORE_SCRIPT}" == "" ]]; then unset BEFORE_SCRIPT; fi
+          if [[ "${BUILDER}" == "" ]]; then unset BUILDER; fi
+          if [[ "${BUILD_PKGS}" == "" ]]; then unset BUILD_PKGS; fi
+          if [[ "${CATKIN_PARALLEL_JOBS}" == "" ]]; then unset CATKIN_PARALLEL_JOBS; fi
+          if [[ "${CATKIN_PARALLEL_TEST_JOBS}" == "" ]]; then unset CATKIN_PARALLEL_TEST_JOBS; fi
+          if [[ "${CATKIN_TOOLS_BUILD_OPTIONS}" == "" ]]; then unset CATKIN_TOOLS_BUILD_OPTIONS; fi
+          if [[ "${CATKIN_TOOLS_CONFIG_OPTIONS}" == "" ]]; then unset CATKIN_TOOLS_CONFIG_OPTIONS; fi
+          if [[ "${CMAKE_DEVELOPER_ERROR}" == "" ]]; then unset CMAKE_DEVELOPER_ERROR; fi
+          if [[ "${DEBUG_TRAVIS_PYTHON}" == "" ]]; then unset DEBUG_TRAVIS_PYTHON; fi
+          if [[ "${DOCKER_IMAGE_JENKINS}" == "" ]]; then unset DOCKER_IMAGE_JENKINS; fi
+          if [[ "${EXTRA_DEB}" == "" ]]; then unset EXTRA_DEB; fi
+          if [[ "${NOT_TEST_INSTALL}" == "" ]]; then unset NOT_TEST_INSTALL; fi
+          if [[ "${ROSDEP_ADDITIONAL_OPTIONS}" == "" ]]; then unset ROSDEP_ADDITIONAL_OPTIONS; fi
+          if [[ "${ROSDEP_UPDATE_QUIET}" == "" ]]; then unset ROSDEP_UPDATE_QUIET; fi
+          if [[ "${ROSWS}" == "" ]]; then unset ROSWS; fi
+          if [[ "${ROS_DISTRO}" == "" ]]; then unset ROS_DISTRO; fi
+          if [[ "${ROS_LOG_DIR}" == "" ]]; then unset ROS_LOG_DIR; fi
+          if [[ "${ROS_PARALLEL_JOBS}" == "" ]]; then unset ROS_PARALLEL_JOBS; fi
+          if [[ "${ROS_PARALLEL_TEST_JOBS}" == "" ]]; then unset ROS_PARALLEL_TEST_JOBS; fi
+          if [[ "${ROS_PYTHON_VERSION}" == "" ]]; then unset ROS_PYTHON_VERSION || ''; fi
+          if [[ "${ROS_REPOSITORY_PATH}" == "" ]]; then unset ROS_REPOSITORY_PATH; fi
+          if [[ "${SUDO_PIP}" == "" ]]; then unset SUDO_PIP; fi
+          if [[ "${TARGET_PKGS}" == "" ]]; then unset TARGET_PKGS; fi
+          if [[ "${TEST_PKGS}" == "" ]]; then unset TEST_PKGS; fi
+          if [[ "${USE_CATKIN_MAKE}" == "" ]]; then unset USE_CATKIN_MAKE; fi
+          if [[ "${USE_DEB}" == "" ]]; then unset USE_DEB; fi
+          if [[ "${USE_JENKINS}" == "" ]]; then unset USE_JENKINS; fi
+          if [[ "${USE_PYTHON_VIRTUALENV}" == "" ]]; then unset USE_PYTHON_VIRTUALENV; fi
+          if [[ "${USE_TRAVIS}" == "" ]]; then unset USE_TRAVIS; fi
+          # to compatible with travis
+          export TRAVIS_BRANCH=${GITHUB_REF#refs/heads/}
+          export TRAVIS_REPO_SLUG=${GITHUB_REPOSITORY}
+          export TRAVIS_JOB_ID=${GITHUB_RUN_ID}
+          export TRAVIS_JOB_NUMBER=${GITHUB_RUN_NUMBER}
+          export TRAVIS_COMMIT=${GITHUB_SHA}
+          export TRAVIS_PULL_REQUEST=false
+          # For testing ADDITIONAL_ENV_TO_DOCKER
+          export TEST_VAR1='true'
+          export TEST_VAR2='false'
+          export ADDITIONAL_ENV_TO_DOCKER='TEST_VAR1 TEST_VAR2'
+          ## start here
+          env
+          if [ "${ROS_DISTRO}" == "hydro" ]; then export BEFORE_SCRIPT="sed -ie \"/-pip/ d\" \${CI_SOURCE_PATH}/package.xml;${BEFORE_SCRIPT}"; fi # FIXME hydro does not have python >= 2.7.9, so it fails on pip install
+          if [ "${ROS_DISTRO}" == "noetic" ]; then export BEFORE_SCRIPT="sed -ie \"/gazebo/ d\" \${CI_SOURCE_PATH}/package.xml;${BEFORE_SCRIPT}"; fi # FIXME gazebo is not released in noetic
+          if [ "${ROS_DISTRO}" == "noetic" ]; then export BEFORE_SCRIPT="touch ros_tutorials/turtlesim/CATKIN_IGNORE; ${BEFORE_SCRIPT}"; fi # qt5/moc does not work on docker (https://stackoverflow.com/questions/56319830/error-when-building-qt-app-in-a-recent-docker)
+          mkdir .travis; mv *.sh *.py *.conf .travis/ # need to move, since directory starting from . is ignoreed by catkin build
+          export BEFORE_SCRIPT="rm -fr jsk_travis/CATKIN_IGNORE; git clone https://github.com/ros/ros_tutorials -b ${ROS_DISTRO}-devel;${BEFORE_SCRIPT}"
+          if [ "${USE_CATKIN_MAKE}" == "true" ] ;then sed -i 's@catkin build -i -v --limit-status-rate 0.001@catkin_make@' .travis/travis.sh; fi
+          if [ "${USE_CATKIN_MAKE}" == "true" ] ;then sed -i 's@catkin run_tests --no-deps --limit-status-rate 0.001@catkin_make run_tests@' .travis/travis.sh; fi
+          if [ "${USE_CATKIN_MAKE}" == "true" ] ;then export CATKIN_PARALLEL_JOBS="--no-color" ; fi
+          if [ "${TEST_GAZEBO}" = "true" ]; then export CATKIN_TOOLS_BUILD_OPTIONS="--force-cmake --cmake-args -DENABLE_TEST_GAZEBO:BOOL=ON --"; fi
+          .travis/travis.sh
+        shell: bash
+      - name: Chcek python3
+        if: matrix.build == 'check_python3'
+        run: |
+          apt update -q && apt install -y -q python3
+          python3 -m compileall .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,202 +1,360 @@
 # jsk_travis
 on: [push]
 
+env:
+  TEST_VAR1: true
+  TEST_VAR2: false
+
 jobs:
-  test:
+  jenkins_hydro:
+    name: jenkins_hydro
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - build: jenkins_hydro
-            USE_JENKINS: true
-            ROS_DISTRO : hydro
-          - build: jenkins_indigo
-            USE_JENKINS: true
-            ROS_DISTRO : indigo
-          - build: jenkins_kinetic
-            USE_JENKINS: true
-            ROS_DISTRO : kinetic
-          - build: jenkins_kinetic_pcl
-            USE_JENKINS: true
-            ROS_DISTRO : kinetic
-            DOCKER_IMAGE_JENKINS : ros-ubuntu:16.04-pcl
-          - build: jenkins_melodic
-            USE_JENKINS: true
-            ROS_DISTRO : melodic
-          - build: jenkins_melodic_pcl
-            USE_JENKINS: true
-            ROS_DISTRO : melodic
-            DOCKER_IMAGE_JENKINS : ros-ubuntu:18.04-pcl
-          - build: jenkins_noetic
-            USE_JENKINS: true
-            ROS_DISTRO : noetic
-          - build: jenkins_noetic_pcl
-            USE_JENKINS: true
-            ROS_DISTRO : noetic
-            DOCKER_IMAGE_JENKINS : ros-ubuntu:20.04-pcl
-          - build: hydro
-            container: ubuntu:12.04
-            ROS_DISTRO : hydro
-          - build: indigo
-            container: ubuntu:14.04
-            ROS_DISTRO : indigo
-          - build: kinetic
-            container: ubuntu:16.04
-            ROS_DISTRO : kinetic
-          - build: melodic
-            container: ubuntu:18.04
-            ROS_DISTRO : melodic
-          - build: melodic_catkin_make
-            container : ubuntu:18.04
-            ROS_DISTRO : melodic
-            USE_CATKIN_MAKE : true
-            BEFORE_SCRIPT : "pwd; git clone http://github.com/jsk-ros-pkg/jsk_common_msgs"
-            NOT_TEST_INSTALL : true
-          - build: melodic_test_packages
-            container : ubuntu:18.04
-            ROS_DISTRO : melodic
-            TEST_PKGS : ""
-          - build: melodic_repository_path
-            container : ubuntu:18.04
-            ROS_DISTRO : melodic
-            ROS_REPOSITORY_PATH : http://packages.ros.org/ros/ubuntu
-          - build: noetic
-            container: ubuntu:20.04
-            ROS_DISTRO : noetic
-          - build: noetic_python2
-            container: ubuntu:20.04
-            ROS_DISTRO : noetic
-            ROS_PYTHON_VERSION : 2
-            ROSDEP_ADDITIONAL_OPTIONS : "-n -q -r --ignore-src"
-            BEFORE_SCRIPT : "sudo pip install empy"
-            TEST_PKGS : "rospy_tutorials"
-          - build: noetic_python3
-            container: ubuntu:20.04
-            ROS_DISTRO : noetic
-            ROS_PYTHON_VERSION : 3
-          - build: check_python3
-            container: ubuntu:20.04
-
-    env:
-      CI_SOURCE_PATH: ${{ github.workspace }}
-      ADDITIONAL_ENV_TO_DOCKER : ${{ matrix.ADDITIONAL_ENV_TO_DOCKER }}
-      BEFORE_SCRIPT : ${{ matrix.BEFORE_SCRIPT }}
-      BUILDER : ${{ matrix.BUILDER }}
-      BUILD_PKGS : ${{ matrix.BUILD_PKGS }}
-      CATKIN_PARALLEL_JOBS : ${{ matrix.CATKIN_PARALLEL_JOBS }}
-      CATKIN_PARALLEL_TEST_JOBS : ${{ matrix.CATKIN_PARALLEL_TEST_JOBS }}
-      CATKIN_TOOLS_BUILD_OPTIONS : ${{ matrix.CATKIN_TOOLS_BUILD_OPTIONS }}
-      CATKIN_TOOLS_CONFIG_OPTIONS : ${{ matrix.CATKIN_TOOLS_CONFIG_OPTIONS }}
-      CMAKE_DEVELOPER_ERROR : ${{ matrix.CMAKE_DEVELOPER_ERROR }}
-      DEBUG_TRAVIS_PYTHON : ${{ matrix.DEBUG_TRAVIS_PYTHON }}
-      DOCKER_IMAGE_JENKINS : ${{ matrix.DOCKER_IMAGE_JENKINS }}
-      EXTRA_DEB : ${{ matrix.EXTRA_DEB }}
-      NOT_TEST_INSTALL : ${{ matrix.NOT_TEST_INSTALL }}
-      ROSDEP_ADDITIONAL_OPTIONS : ${{ matrix.ROSDEP_ADDITIONAL_OPTIONS || '-n -v --ignore-src' }}  # run rosdep without -q, -r and -v
-      ROSDEP_UPDATE_QUIET : ${{ matrix.ROSDEP_UPDATE_QUIET }}
-      ROSWS : ${{ matrix.ROSWS }}
-      ROS_DISTRO : ${{ matrix.ROS_DISTRO }}
-      ROS_LOG_DIR : ${{ matrix.ROS_LOG_DIR }}
-      ROS_PARALLEL_JOBS : ${{ matrix.ROS_PARALLEL_JOBS }}
-      ROS_PARALLEL_TEST_JOBS : ${{ matrix.ROS_PARALLEL_TEST_JOBS }}
-      ROS_PYTHON_VERSION : ${{ matrix.ROS_PYTHON_VERSION || '' }}
-      ROS_REPOSITORY_PATH : ${{ matrix.ROS_REPOSITORY_PATH }}
-      SUDO_PIP : ${{ matrix.SUDO_PIP }}
-      TARGET_PKGS : ${{ matrix.TARGET_PKGS }}
-      TEST_PKGS : ${{ matrix.TEST_PKGS }}
-      USE_CATKIN_MAKE : ${{ matrix.USE_CATKIN_MAKE }}
-      USE_DEB : ${{ matrix.USE_DEB }}
-      USE_JENKINS : ${{ matrix.USE_JENKINS || 'false' }}
-      USE_PYTHON_VIRTUALENV : ${{ matrix.USE_PYTHON_VIRTUALENV }}
-      USE_TRAVIS : ${{ matrix.USE_JENKINS == true && 'false' || 'true' }} # if not use_jenkins, use travis(actions)
-
-    name: ${{ matrix.ROS_DISTRO || matrix.build }}${{ matrix.USE_JENKINS && '+jenkins' || '' }}${{ matrix.ROS_PYTHON_VERSION == '2' && '+python2' || '' }}${{ matrix.ROS_PYTHON_VERSION == '3' && '+python3' || '' }}${{ matrix.ROS_REPOSITORY_PATH }}${{ matrix.BEFORE_SCRIPT && toJSON(matrix.BEFORE_SCRIPT) || '' }}${{ matrix.TARGET_PKGS && toJSON(matrix.TARGET_PKGS) || '' }}${{ matrix.TEST_PKGS && toJSON(matrix.TEST_PKGS) || '' }}${{ matrix.DOCKER_IMAGE_JENKINS && toJSON(matrix.DOCKER_IMAGE_JENKINS) || '' }}
-
-    container: ${{ matrix.container || 'ubuntu:18.04' }}
-
+    container: ubuntu:18.04
     steps:
-      - name: Chcekout
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
-        if: ${{ ! ( matrix.ROS_DISTRO == 'hydro' &&  matrix.USE_JENKINS != 'true' ) }}
-      - name: Chcekout # hydro container does not work with actions/checkout@v2
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ADDITIONAL_ENV_TO_DOCKER: 'TEST_VAR1 TEST_VAR2'
+          USE_JENKINS: true
+          ROS_DISTRO : hydro
+
+  jenkins_indigo:
+    name: jenkins_indigo
+    runs-on: ubuntu-latest
+    container: ubuntu:18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ADDITIONAL_ENV_TO_DOCKER: 'TEST_VAR1 TEST_VAR2'
+          USE_JENKINS: true
+          ROS_DISTRO : indigo
+
+  jenkins_kinetic:
+    name: jenkins_kinetic
+    runs-on: ubuntu-latest
+    container: ubuntu:18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ADDITIONAL_ENV_TO_DOCKER: 'TEST_VAR1 TEST_VAR2'
+          USE_JENKINS: true
+          ROS_DISTRO : kinetic
+
+  jenkins_kinetic_pcl:
+    name: jenkins_kinetic_pcl
+    runs-on: ubuntu-latest
+    container: ubuntu:18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ADDITIONAL_ENV_TO_DOCKER: 'TEST_VAR1 TEST_VAR2'
+          USE_JENKINS: true
+          ROS_DISTRO : kinetic
+          DOCKER_IMAGE_JENKINS : ros-ubuntu:16.04-pcl
+
+  jenkins_melodic:
+    name: jenkins_melodic
+    runs-on: ubuntu-latest
+    container: ubuntu:18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ADDITIONAL_ENV_TO_DOCKER: 'TEST_VAR1 TEST_VAR2'
+          USE_JENKINS: true
+          ROS_DISTRO : melodic
+
+  jenkins_melodic_pcl:
+    name: jenkins_melodic_pcl
+    runs-on: ubuntu-latest
+    container: ubuntu:18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ADDITIONAL_ENV_TO_DOCKER: 'TEST_VAR1 TEST_VAR2'
+          USE_JENKINS: true
+          ROS_DISTRO : melodic
+          DOCKER_IMAGE_JENKINS : ros-ubuntu:18.04-pcl
+
+  jenkins_noetic:
+    name: jenkins_noetic
+    runs-on: ubuntu-latest
+    container: ubuntu:18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ADDITIONAL_ENV_TO_DOCKER: 'TEST_VAR1 TEST_VAR2'
+          USE_JENKINS: true
+          ROS_DISTRO : noetic
+
+  jenkins_noetic_pcl:
+    name: jenkins_noetic_pcl
+    runs-on: ubuntu-latest
+    container: ubuntu:18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ADDITIONAL_ENV_TO_DOCKER: 'TEST_VAR1 TEST_VAR2'
+          USE_JENKINS: true
+          ROS_DISTRO : noetic
+          DOCKER_IMAGE_JENKINS : ros-ubuntu:20.04-pcl
+
+  hydro:
+    name: hydro
+    runs-on: ubuntu-latest
+    container: ubuntu:12.04
+    steps:
+      - name: Checkout
         uses: actions/checkout@v1
         with:
           fetch-depth: 2
-        if: ${{ matrix.ROS_DISTRO == 'hydro' &&  matrix.USE_JENKINS != 'true' }}
-      - name: Install system commands
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          apt-get -y -qq update
-          apt-get -y -qq install sudo
-          # install fundamental packages
-          sudo -E apt-get -y -qq update
-          sudo -E apt-get -y -qq install apt-utils build-essential curl git lsb-release wget
-          # 20.04 does not have pip, so install get-pip.py
-          sudo -E apt-get -y -qq install python-pip python-setuptools || (sudo -E apt-get -y -qq install python; curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | sudo -E python; sudo -E apt-get -y -qq install python3-pip)
-      - name: Run jsk_travis test
-        if: matrix.ROS_DISTRO != ''
-        run: |
-          set -x
-          # unset if  not defined
-          if [[ "${ADDITIONAL_ENV_TO_DOCKER}" == "" ]]; then unset ADDITIONAL_ENV_TO_DOCKER; fi
-          if [[ "${BEFORE_SCRIPT}" == "" ]]; then unset BEFORE_SCRIPT; fi
-          if [[ "${BUILDER}" == "" ]]; then unset BUILDER; fi
-          if [[ "${BUILD_PKGS}" == "" ]]; then unset BUILD_PKGS; fi
-          if [[ "${CATKIN_PARALLEL_JOBS}" == "" ]]; then unset CATKIN_PARALLEL_JOBS; fi
-          if [[ "${CATKIN_PARALLEL_TEST_JOBS}" == "" ]]; then unset CATKIN_PARALLEL_TEST_JOBS; fi
-          if [[ "${CATKIN_TOOLS_BUILD_OPTIONS}" == "" ]]; then unset CATKIN_TOOLS_BUILD_OPTIONS; fi
-          if [[ "${CATKIN_TOOLS_CONFIG_OPTIONS}" == "" ]]; then unset CATKIN_TOOLS_CONFIG_OPTIONS; fi
-          if [[ "${CMAKE_DEVELOPER_ERROR}" == "" ]]; then unset CMAKE_DEVELOPER_ERROR; fi
-          if [[ "${DEBUG_TRAVIS_PYTHON}" == "" ]]; then unset DEBUG_TRAVIS_PYTHON; fi
-          if [[ "${DOCKER_IMAGE_JENKINS}" == "" ]]; then unset DOCKER_IMAGE_JENKINS; fi
-          if [[ "${EXTRA_DEB}" == "" ]]; then unset EXTRA_DEB; fi
-          if [[ "${NOT_TEST_INSTALL}" == "" ]]; then unset NOT_TEST_INSTALL; fi
-          if [[ "${ROSDEP_ADDITIONAL_OPTIONS}" == "" ]]; then unset ROSDEP_ADDITIONAL_OPTIONS; fi
-          if [[ "${ROSDEP_UPDATE_QUIET}" == "" ]]; then unset ROSDEP_UPDATE_QUIET; fi
-          if [[ "${ROSWS}" == "" ]]; then unset ROSWS; fi
-          if [[ "${ROS_DISTRO}" == "" ]]; then unset ROS_DISTRO; fi
-          if [[ "${ROS_LOG_DIR}" == "" ]]; then unset ROS_LOG_DIR; fi
-          if [[ "${ROS_PARALLEL_JOBS}" == "" ]]; then unset ROS_PARALLEL_JOBS; fi
-          if [[ "${ROS_PARALLEL_TEST_JOBS}" == "" ]]; then unset ROS_PARALLEL_TEST_JOBS; fi
-          if [[ "${ROS_PYTHON_VERSION}" == "" ]]; then unset ROS_PYTHON_VERSION || ''; fi
-          if [[ "${ROS_REPOSITORY_PATH}" == "" ]]; then unset ROS_REPOSITORY_PATH; fi
-          if [[ "${SUDO_PIP}" == "" ]]; then unset SUDO_PIP; fi
-          if [[ "${TARGET_PKGS}" == "" ]]; then unset TARGET_PKGS; fi
-          if [[ "${TEST_PKGS}" == "" ]]; then unset TEST_PKGS; fi
-          if [[ "${USE_CATKIN_MAKE}" == "" ]]; then unset USE_CATKIN_MAKE; fi
-          if [[ "${USE_DEB}" == "" ]]; then unset USE_DEB; fi
-          if [[ "${USE_JENKINS}" == "" ]]; then unset USE_JENKINS; fi
-          if [[ "${USE_PYTHON_VIRTUALENV}" == "" ]]; then unset USE_PYTHON_VIRTUALENV; fi
-          if [[ "${USE_TRAVIS}" == "" ]]; then unset USE_TRAVIS; fi
-          # to compatible with travis
-          export TRAVIS_BRANCH=${GITHUB_REF#refs/heads/}
-          export TRAVIS_REPO_SLUG=${GITHUB_REPOSITORY}
-          export TRAVIS_JOB_ID=${GITHUB_RUN_ID}
-          export TRAVIS_JOB_NUMBER=${GITHUB_RUN_NUMBER}
-          export TRAVIS_COMMIT=${GITHUB_SHA}
-          export TRAVIS_PULL_REQUEST=false
-          # For testing ADDITIONAL_ENV_TO_DOCKER
-          export TEST_VAR1='true'
-          export TEST_VAR2='false'
-          export ADDITIONAL_ENV_TO_DOCKER='TEST_VAR1 TEST_VAR2'
-          ## start here
-          env
-          if [ "${ROS_DISTRO}" == "hydro" ]; then export BEFORE_SCRIPT="sed -ie \"/-pip/ d\" \${CI_SOURCE_PATH}/package.xml;${BEFORE_SCRIPT}"; fi # FIXME hydro does not have python >= 2.7.9, so it fails on pip install
-          if [ "${ROS_DISTRO}" == "noetic" ]; then export BEFORE_SCRIPT="sed -ie \"/gazebo/ d\" \${CI_SOURCE_PATH}/package.xml;${BEFORE_SCRIPT}"; fi # FIXME gazebo is not released in noetic
-          if [ "${ROS_DISTRO}" == "noetic" ]; then export BEFORE_SCRIPT="touch ros_tutorials/turtlesim/CATKIN_IGNORE; ${BEFORE_SCRIPT}"; fi # qt5/moc does not work on docker (https://stackoverflow.com/questions/56319830/error-when-building-qt-app-in-a-recent-docker)
-          mkdir .travis; mv *.sh *.py *.conf .travis/ # need to move, since directory starting from . is ignoreed by catkin build
-          export BEFORE_SCRIPT="rm -fr jsk_travis/CATKIN_IGNORE; git clone https://github.com/ros/ros_tutorials -b ${ROS_DISTRO}-devel;${BEFORE_SCRIPT}"
-          if [ "${USE_CATKIN_MAKE}" == "true" ] ;then sed -i 's@catkin build -i -v --limit-status-rate 0.001@catkin_make@' .travis/travis.sh; fi
-          if [ "${USE_CATKIN_MAKE}" == "true" ] ;then sed -i 's@catkin run_tests --no-deps --limit-status-rate 0.001@catkin_make run_tests@' .travis/travis.sh; fi
-          if [ "${USE_CATKIN_MAKE}" == "true" ] ;then export CATKIN_PARALLEL_JOBS="--no-color" ; fi
-          if [ "${TEST_GAZEBO}" = "true" ]; then export CATKIN_TOOLS_BUILD_OPTIONS="--force-cmake --cmake-args -DENABLE_TEST_GAZEBO:BOOL=ON --"; fi
-          .travis/travis.sh
-        shell: bash
-      - name: Chcek python3
-        if: matrix.build == 'check_python3'
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ADDITIONAL_ENV_TO_DOCKER: 'TEST_VAR1 TEST_VAR2'
+          ROS_DISTRO : hydro
+
+  indigo:
+    name: indigo
+    runs-on: ubuntu-latest
+    container: ubuntu:14.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+           fetch-depth: 2
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ADDITIONAL_ENV_TO_DOCKER: 'TEST_VAR1 TEST_VAR2'
+          ROS_DISTRO : indigo
+
+  kinetic:
+    name: kinetic
+    runs-on: ubuntu-latest
+    container: ubuntu:16.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ADDITIONAL_ENV_TO_DOCKER: 'TEST_VAR1 TEST_VAR2'
+          ROS_DISTRO : kinetic
+
+  melodic:
+    name: melodic
+    runs-on: ubuntu-latest
+    container: ubuntu:18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ADDITIONAL_ENV_TO_DOCKER: 'TEST_VAR1 TEST_VAR2'
+          ROS_DISTRO : melodic
+
+  melodic_catkin_make:
+    name: melodic_catkin_make
+    runs-on: ubuntu-latest
+    container: ubuntu:18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ADDITIONAL_ENV_TO_DOCKER: 'TEST_VAR1 TEST_VAR2'
+          ROS_DISTRO : melodic
+          USE_CATKIN_MAKE : true
+          BEFORE_SCRIPT : "pwd; git clone http://github.com/jsk-ros-pkg/jsk_common_msgs"
+          NOT_TEST_INSTALL : true
+
+  melodic_test_packages:
+    name: melodic_test_packages
+    runs-on: ubuntu-latest
+    container : ubuntu:18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ADDITIONAL_ENV_TO_DOCKER: 'TEST_VAR1 TEST_VAR2'
+          ROS_DISTRO : melodic
+          TEST_PKGS : ""
+
+  melodic_repository_path:
+    name: melodic_repository_path
+    runs-on: ubuntu-latest
+    container : ubuntu:18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ADDITIONAL_ENV_TO_DOCKER: 'TEST_VAR1 TEST_VAR2'
+          ROS_DISTRO : melodic
+          ROS_REPOSITORY_PATH : http://packages.ros.org/ros/ubuntu
+
+  noetic:
+    name: noetic
+    runs-on: ubuntu-latest
+    container : ubuntu:20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ADDITIONAL_ENV_TO_DOCKER: 'TEST_VAR1 TEST_VAR2'
+          ROS_DISTRO : noetic
+
+  noetic_python2:
+    name: noetic_python2
+    runs-on: ubuntu-latest
+    container : ubuntu:20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ADDITIONAL_ENV_TO_DOCKER: 'TEST_VAR1 TEST_VAR2'
+          ROS_DISTRO : noetic
+          ROS_PYTHON_VERSION : 2
+          ROSDEP_ADDITIONAL_OPTIONS : "-n -q -r --ignore-src"
+          BEFORE_SCRIPT : "sudo pip install empy"
+          TEST_PKGS : "rospy_tutorials"
+
+  noetic_python3:
+    name: noetic_python3
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ADDITIONAL_ENV_TO_DOCKER: 'TEST_VAR1 TEST_VAR2'
+          ROS_DISTRO : noetic
+          ROS_PYTHON_VERSION : 3
+
+  docker_kinetic:
+    name: docker_kinetic
+    runs-on: ubuntu-latest
+    container: jskrobotics/ros-ubuntu:16.04
+    steps:
+      - name: Before Checkout # need for actoins/checkout with ros-ubuntu container
+        run: sudo chown -R user:jenkins $RUNNER_WORKSPACE $HOME
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ADDITIONAL_ENV_TO_DOCKER: 'TEST_VAR1 TEST_VAR2'
+          ROS_DISTRO : kinetic
+
+  docker_melodic:
+    name: docker_melodic
+    runs-on: ubuntu-latest
+    container: jskrobotics/ros-ubuntu:18.04
+    steps:
+      - name: Before Checkout # need for actoins/checkout with ros-ubuntu container
+        run: sudo chown -R user:jenkins $RUNNER_WORKSPACE $HOME
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ADDITIONAL_ENV_TO_DOCKER: 'TEST_VAR1 TEST_VAR2'
+          ROS_DISTRO : melodic
+
+  docker_noetic:
+    name: docker_noetic
+    runs-on: ubuntu-latest
+    container: jskrobotics/ros-ubuntu:20.04
+    steps:
+      - name: Before Checkout # need for actoins/checkout with ros-ubuntu container
+        run: sudo chown -R user:jenkins $RUNNER_WORKSPACE $HOME
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ADDITIONAL_ENV_TO_DOCKER: 'TEST_VAR1 TEST_VAR2'
+          ROS_DISTRO : noetic
+
+  check_python3:
+    name: check_python3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Check python3
         run: |
           apt update -q && apt install -y -q python3
           python3 -m compileall .

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Join the chat at https://gitter.im/jsk-ros-pkg/jsk_travis](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/jsk-ros-pkg/jsk_travis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/jsk-ros-pkg/jsk_travis.svg?branch=master)](https://travis-ci.org/jsk-ros-pkg/jsk_travis)
+[![.github/workflows/main.yml](https://github.com/jsk-ros-pkg/jsk_travis/actions/workflows/main.yml/badge.svg)](https://github.com/jsk-ros-pkg/jsk_travis/actions/workflows/main.yml)
 
 ![](_media/jsk_travis_diagram.png)
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,198 @@
+name: 'Dockerfile for speedup jsk_travis'
+author: 'JSK Robotics Laboratory'
+description: 'Dockerfile for speedup jsk_travis, try docker run --rm -ti jskrobotics:ros-ubuntu:18.04-pcl'
+inputs:
+  ROS_DISTRO:
+    description: 'Specify your target distribution of ROS'
+    required: true
+    default: melodic
+  ADDITIONAL_ENV_TO_DOCKER:
+    description: >
+      Specify environment variables you want to pass to docker on
+      travis/jenkins. You can specify multiple variables separated by
+      a space. e.g. `IS_EUSLISP_TRAVIS_TEST IS_GAZEBO_TRAVIS_TEST`
+  BEFORE_SCRIPT:
+    description: >
+      `BEFORE_SCRIPT` is used to specify shell commands which run
+      before building packages. Some characters won\'t work without
+      escaping it for xml on Jenkins. (see:
+        [here](https://github.com/jsk-ros-pkg/jsk_travis/issues/171))
+  BUILD_PKGS:
+    description: >
+      You can specify the packages to build and test. If your
+      repository has some troubles about several packages, you can
+      ignore them by this option like `BUILD_PKGS="jsk_pcl_ros
+      jsk_recognition_msgs"`.
+  CATKIN_PARALLEL_JOBS:
+    description: >
+      The number of catkin parallel processes in build.
+  CATKIN_PARALLEL_TEST_JOBS:
+    description: >
+      The number of catkin parallel processes in test.
+    default: '-p4'
+  CATKIN_TOOLS_BUILD_OPTIONS:
+    description: >
+      Options to be passed like `catkin build
+      $CATKIN_TOOLS_BUILD_OPTIONS`. (default: `-iv --summarize
+      --no-status` for `catkin-tools==0.3.X`  and `--summarize
+      --no-status` for `catkin-tools` of other version.)
+  CATKIN_TOOLS_CONFIG_OPTIONS:
+    description: >
+      Options to be passed like `catkin config
+      $CATKIN_TOOLS_CONFIG_OPTIONS`.
+  CMAKE_DEVELOPER_ERROR:
+    description: >
+      Flag to show CMake developer error in catkin run_tests.
+  DEBUG_TRAVIS_PYTHON:
+    description: >
+      Specify python command to run within travis/docker/jenkins, for
+      example set `DEBUG_TRAVIS_PYTHON` to `python -v`
+  DOCKER_IMAGE_JENKINS:
+    description: >
+      Docker image used in Jenkins., (defualt:
+        `ros-ubuntu:$(lsb_release -sr)`)
+  EXTRA_DEB:
+    description: >
+      You can specify extra deb packages by `EXTRA_DEB` variable. The
+      packages are installed before building packages.
+  NOT_TEST_INSTALL:
+    description: >
+      Flag to skip testing catkin install in addition to devel
+      build. i.e. If true, skip testing.
+  ROSDEP_ADDITIONAL_OPTIONS:
+    description: >
+      The options passed when rosdep install.(default: \'-n -q -r
+      --ignore-src\')
+  ROSDEP_UPDATE_QUIET:
+    description: >
+      Set true to disable verbose option for \'rosdep update\'
+  ROS_LOG_DIR:
+    description: >
+      Specify ROS_LOG_DIR
+      (http://wiki.ros.org/ROS/EnvironmentVariables#ROS_LOG_DIR),
+      otherwise uses ~/.ros/test_results
+  ROS_PARALLEL_JOBS:
+    description: >
+      Specify ROS_PARALLEL_JOBS environment, (defult: -j8)
+  ROS_PARALLEL_TEST_JOBS:
+    description: >
+      Specify ROS_PARALLEL_TEST_JOBS environment, (defult: -j8)
+  ROS_PYTHON_VERSION:
+    description: >
+      Specify your target python version used of ROS. Available from
+      Noetic. see [Build Using
+      Python3](http://wiki.ros.org/UsingPython3/BuildUsingPython3) and
+      [rep 149](https://github.com/ros-infrastructure/rep/blob/master/rep-0149.rst)
+  ROS_REPOSITORY_PATH:
+    description: >
+      Specify ROS repository path, (defualt:
+        http://packages.ros.org/ros-testing/ubuntu)
+  TARGET_PKGS:
+    description: >
+      Specify packages to build
+  TEST_PKGS:
+    description: >
+      Specify packages to test
+  USE_CATKIN_MAKE:
+    description: >
+      Set true to use `catkin_make`
+  USE_DEB:
+    description: >
+      If `false`, travis firstly sees [config
+      files](https://github.com/jsk-ros-pkg/jsk_travis#config-files)
+      to resolve dependencies and then installs left dependencies by
+      apt. If `source`, travis does not sees [config
+      files](https://github.com/jsk-ros-pkg/jsk_travis#config-files)
+      but runs `setup_upstream.sh`
+      file. See [here](https://github.com/jsk-ros-pkg/jsk_roseus) for
+      example.
+  USE_JENKINS:
+    description: >
+      Force to run test on jenkins. jenkins server is more powerful
+      than travis environment, so we can use jenkins to compile
+      pcl-related packages such as
+      [jsk_recognition](https://github.com/jsk-ros-pkg/jsk_recognition.git). This
+      variable needs to be `true` to run test with [container-based travis
+      environment](http://docs.travis-ci.com/user/workers/container-based-infrastructure/). This
+      overwrites default configuration described
+      [here](https://github.com/jsk-ros-pkg/jsk_travis#where-test-runs).
+    default: 'false'
+  USE_PYTHON_VIRTUALENV:
+    description: >
+      Set true to use python virtualenv
+  USE_TRAVIS:
+    description: >
+      force to run test on Github Actions
+
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install system commands
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        if [ "$EUID" -eq 0 ]; then # if we run with root
+          apt-get -y -qq update
+          apt-get -y -qq install sudo
+        fi
+        # install fundamental packages
+        sudo -E apt-get -y -qq update
+        sudo -E apt-get -y -qq install apt-utils build-essential curl git lsb-release wget
+        # 20.04 does not have pip, so install get-pip.py
+        sudo -E apt-get -y -qq install python-pip python-setuptools || (sudo -E apt-get -y -qq install python; curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | sudo -E python; sudo -E apt-get -y -qq install python3-pip)
+      shell: bash
+    - name: Run jsk_travis test
+      run: |
+        set -x
+        # unset if  not defined
+        if [[ "${{ inputs.ADDITIONAL_ENV_TO_DOCKER }}" != "" ]]; then export ADDITIONAL_ENV_TO_DOCKER="${{ inputs.ADDITIONAL_ENV_TO_DOCKER }}"; fi
+        if [[ "${{ inputs.BEFORE_SCRIPT }}" != "" ]]; then export BEFORE_SCRIPT="${{ inputs.BEFORE_SCRIPT }}"; fi
+        if [[ "${{ inputs.BUILD_PKGS }}" != "" ]]; then export BUILD_PKGS="${{ inputs.BUILD_PKGS }}"; fi
+        if [[ "${{ inputs.CATKIN_PARALLEL_JOBS }}" != "" ]]; then export CATKIN_PARALLEL_JOBS="${{ inputs.CATKIN_PARALLEL_JOBS }}"; fi
+        if [[ "${{ inputs.CATKIN_PARALLEL_TEST_JOBS }}" != "" ]]; then export CATKIN_PARALLEL_TEST_JOBS="${{ inputs.CATKIN_PARALLEL_TEST_JOBS }}"; fi
+        if [[ "${{ inputs.CATKIN_TOOLS_BUILD_OPTIONS }}" != "" ]]; then export CATKIN_TOOLS_BUILD_OPTIONS="${{ inputs.CATKIN_TOOLS_BUILD_OPTIONS }}"; fi
+        if [[ "${{ inputs.CATKIN_TOOLS_CONFIG_OPTIONS }}" != "" ]]; then export CATKIN_TOOLS_CONFIG_OPTIONS="${{ inputs.CATKIN_TOOLS_CONFIG_OPTIONS }}"; fi
+        if [[ "${{ inputs.CMAKE_DEVELOPER_ERROR }}" != "" ]]; then export CMAKE_DEVELOPER_ERROR="${{ inputs.CMAKE_DEVELOPER_ERROR }}"; fi
+        if [[ "${{ inputs.DEBUG_TRAVIS_PYTHON }}" != "" ]]; then export DEBUG_TRAVIS_PYTHON="${{ inputs.DEBUG_TRAVIS_PYTHON }}"; fi
+        if [[ "${{ inputs.DOCKER_IMAGE_JENKINS }}" != "" ]]; then export DOCKER_IMAGE_JENKINS="${{ inputs.DOCKER_IMAGE_JENKINS }}"; fi
+        if [[ "${{ inputs.EXTRA_DEB }}" != "" ]]; then export EXTRA_DEB="${{ inputs.EXTRA_DEB }}"; fi
+        if [[ "${{ inputs.NOT_TEST_INSTALL }}" != "" ]]; then export NOT_TEST_INSTALL="${{ inputs.NOT_TEST_INSTALL }}"; fi
+        if [[ "${{ inputs.ROSDEP_ADDITIONAL_OPTIONS }}" != "" ]]; then export ROSDEP_ADDITIONAL_OPTIONS="${{ inputs.ROSDEP_ADDITIONAL_OPTIONS }}"; fi
+        if [[ "${{ inputs.ROSDEP_UPDATE_QUIET }}" != "" ]]; then export ROSDEP_UPDATE_QUIET="${{ inputs.ROSDEP_UPDATE_QUIET }}"; fi
+        if [[ "${{ inputs.ROS_DISTRO }}" != "" ]]; then export ROS_DISTRO="${{ inputs.ROS_DISTRO }}"; fi
+        if [[ "${{ inputs.ROS_LOG_DIR }}" != "" ]]; then export ROS_LOG_DIR="${{ inputs.ROS_LOG_DIR }}"; fi
+        if [[ "${{ inputs.ROS_PARALLEL_JOBS }}" != "" ]]; then export ROS_PARALLEL_JOBS="${{ inputs.ROS_PARALLEL_JOBS }}"; fi
+        if [[ "${{ inputs.ROS_PARALLEL_TEST_JOBS }}" != "" ]]; then export ROS_PARALLEL_TEST_JOBS="${{ inputs.ROS_PARALLEL_TEST_JOBS }}"; fi
+        if [[ "${{ inputs.ROS_PYTHON_VERSION }}" != "" ]]; then export ROS_PYTHON_VERSION="${{ inputs.ROS_PYTHON_VERSION }}"; fi
+        if [[ "${{ inputs.ROS_REPOSITORY_PATH }}" != "" ]]; then export ROS_REPOSITORY_PATH="${{ inputs.ROS_REPOSITORY_PATH }}"; fi
+        if [[ "${{ inputs.TARGET_PKGS }}" != "" ]]; then export TARGET_PKGS="${{ inputs.TARGET_PKGS }}"; fi
+        if [[ "${{ inputs.TEST_PKGS }}" != "" ]]; then export TEST_PKGS="${{ inputs.TEST_PKGS }}"; fi
+        if [[ "${{ inputs.USE_CATKIN_MAKE }}" != "" ]]; then export USE_CATKIN_MAKE="${{ inputs.USE_CATKIN_MAKE }}"; fi
+        if [[ "${{ inputs.USE_DEB }}" != "" ]]; then export USE_DEB="${{ inputs.USE_DEB }}"; fi
+        if [[ "${{ inputs.USE_JENKINS }}" != "" ]]; then export USE_JENKINS="${{ inputs.USE_JENKINS }}"; else export USE_JENKINS="false"; fi
+        if [[ "${{ inputs.USE_PYTHON_VIRTUALENV }}" != "" ]]; then export USE_PYTHON_VIRTUALENV="${{ inputs.USE_PYTHON_VIRTUALENV }}"; fi
+        if [[ "${{ inputs.USE_TRAVIS }}" != "" ]]; then export USE_TRAVIS="${{ inputs.USE_TRAVIS }}"; else if [[ "${{ inputs.USE_JENKINS }}" == "true" ]]; then export USE_TRAVIS="false"; else export USE_TRAVIS="true"; fi; fi # if not USE_JENKINS, use travis(github actions)
+        # to compatible with travis
+        export TRAVIS_BRANCH=${GITHUB_REF#refs/heads/}
+        export TRAVIS_REPO_SLUG=${GITHUB_REPOSITORY}
+        export TRAVIS_JOB_ID=${GITHUB_RUN_ID}
+        export TRAVIS_JOB_NUMBER=${GITHUB_RUN_NUMBER}
+        export TRAVIS_COMMIT=${GITHUB_SHA}
+        export TRAVIS_PULL_REQUEST=false
+        ## start here
+        env
+        if [ "${ROS_DISTRO}" == "hydro" ]; then export BEFORE_SCRIPT="sed -ie \"/-pip/ d\" \${CI_SOURCE_PATH}/package.xml;${BEFORE_SCRIPT}"; fi # FIXME hydro does not have python >= 2.7.9, so it fails on pip install
+        if [ "${ROS_DISTRO}" == "noetic" ]; then export BEFORE_SCRIPT="sed -ie \"/gazebo/ d\" \${CI_SOURCE_PATH}/package.xml;${BEFORE_SCRIPT}"; fi # FIXME gazebo is not released in noetic
+        if [ "${ROS_DISTRO}" == "noetic" ]; then export BEFORE_SCRIPT="touch ros_tutorials/turtlesim/CATKIN_IGNORE; ${BEFORE_SCRIPT}"; fi # qt5/moc does not work on docker (https://stackoverflow.com/questions/56319830/error-when-building-qt-app-in-a-recent-docker)
+        mkdir .travis; mv *.sh *.py *.conf .travis/ # need to move, since directory starting from . is ignoreed by catkin build
+        export BEFORE_SCRIPT="rm -fr jsk_travis/CATKIN_IGNORE; git clone https://github.com/ros/ros_tutorials -b ${ROS_DISTRO}-devel;${BEFORE_SCRIPT}"
+        if [ "${USE_CATKIN_MAKE}" == "true" ] ;then sed -i 's@catkin build -i -v --limit-status-rate 0.001@catkin_make@' .travis/travis.sh; fi
+        if [ "${USE_CATKIN_MAKE}" == "true" ] ;then sed -i 's@catkin run_tests --no-deps --limit-status-rate 0.001@catkin_make run_tests@' .travis/travis.sh; fi
+        if [ "${USE_CATKIN_MAKE}" == "true" ] ;then export CATKIN_PARALLEL_JOBS="--no-color" ; fi
+        if [ "${TEST_GAZEBO}" = "true" ]; then export CATKIN_TOOLS_BUILD_OPTIONS="--force-cmake --cmake-args -DENABLE_TEST_GAZEBO:BOOL=ON --"; fi
+        .travis/travis.sh
+      shell: bash
+
+branding:
+  icon: 'wind'
+  color: 'blue'

--- a/travis_jenkins.py
+++ b/travis_jenkins.py
@@ -42,7 +42,12 @@ CONFIGURE_XML = '''<?xml version='1.0' encoding='UTF-8'?>
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.TextParameterDefinition>
-          <name>TRAVIS_JENKINS_UNIQUE_ID</name>
+          <name>TRAVIS_BRANCH</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>TRAVIS_COMMIT</name>
           <description></description>
           <defaultValue></defaultValue>
         </hudson.model.TextParameterDefinition>
@@ -52,7 +57,162 @@ CONFIGURE_XML = '''<?xml version='1.0' encoding='UTF-8'?>
           <defaultValue></defaultValue>
         </hudson.model.TextParameterDefinition>
         <hudson.model.TextParameterDefinition>
-          <name>TRAVIS_COMMIT</name>
+          <name>TRAVIS_REPO_SLUG</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>TRAVIS_BUILD_ID</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>TRAVIS_BUILD_NUMBER</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>TRAVIS_JOB_ID</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>TRAVIS_JOB_NUMBER</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>TRAVIS_JENKINS_UNIQUE_ID</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>ROS_DISTRO</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>USE_DEB</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>EXTRA_DEB</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>TEST_PKGS</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>TARGET_PKGS</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>BEFORE_SCRIPT</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>NOT_TEST_INSTALL</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>ROS_PARALLEL_JOBS</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>ROS_PYTHON_VERSION</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>CATKIN_PARALLEL_JOBS</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>CATKIN_TOOLS_BUILD_OPTIONS</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>CATKIN_TOOLS_CONFIG_OPTIONS</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>ROS_PARALLEL_TEST_JOBS</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>CATKIN_PARALLEL_TEST_JOBS</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>CMAKE_DEVELOPER_ERROR</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>BUILD_PKGS</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>ROS_REPOSITORY_PATH</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>ROSDEP_ADDITIONAL_OPTIONS</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>DOCKER_CONTAINER_NAME</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>DOCKER_RUN_OPTION</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>NUMBER_OF_LOGS_TO_KEEP</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>REPOSITORY_NAME</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>TRAVIS_BUILD_WEB_URL</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>TRAVIS_JOB_WEB_URL</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>DOCKER_IMAGE_JENKINS</name>
+          <description></description>
+          <defaultValue></defaultValue>
+        </hudson.model.TextParameterDefinition>
+        <hudson.model.TextParameterDefinition>
+          <name>ADD_ENV_VALUE_TO_DOCKER</name>
           <description></description>
           <defaultValue></defaultValue>
         </hudson.model.TextParameterDefinition>
@@ -99,13 +259,13 @@ WORKSPACE=`pwd`
 trap "set +x" EXIT
 
 # try git clone until success
-until git clone https://github.com/%(TRAVIS_REPO_SLUG)s ${BUILD_TAG}/%(TRAVIS_REPO_SLUG)s
+until git clone https://github.com/$TRAVIS_REPO_SLUG ${BUILD_TAG}/$TRAVIS_REPO_SLUG
 do
   echo "Retrying"
 done
-cd ${BUILD_TAG}/%(TRAVIS_REPO_SLUG)s
+cd ${BUILD_TAG}/$TRAVIS_REPO_SLUG
 #git fetch -q origin '+refs/pull/*:refs/remotes/pull/*'
-#git checkout -qf %(TRAVIS_COMMIT)s || git checkout -qf pull/${TRAVIS_PULL_REQUEST}/head
+#git checkout -qf $TRAVIS_COMMIT || git checkout -qf pull/${TRAVIS_PULL_REQUEST}/head
 if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
  git fetch -q origin +refs/pull/${TRAVIS_PULL_REQUEST}/merge
  git checkout -qf FETCH_HEAD
@@ -116,7 +276,7 @@ fi
 git submodule init
 git submodule update
 
-if [ "%(REPOSITORY_NAME)s" = "jsk_travis" ]; then
+if [ "$REPOSITORY_NAME" = "jsk_travis" ]; then
   mkdir .travis; cp -r * .travis # need to copy, since directory starting from . is ignoreed by catkin build
 fi
 
@@ -124,41 +284,67 @@ travis_time_end
 # travis_time_start docker_build
 
 # # run docker build
-# docker build -t %(DOCKER_IMAGE_JENKINS)s -f $(echo .travis/docker/Dockerfile.%(DOCKER_IMAGE_JENKINS)s | sed -e s/-[^-]*\$//) .travis/docker
-# docker build -t %(DOCKER_IMAGE_JENKINS)s --build-arg CACHEBUST=$(date +%%Y%%m%%d) -f .travis/docker/Dockerfile.%(DOCKER_IMAGE_JENKINS)s .travis/docker
+# docker build -t $DOCKER_IMAGE_JENKINS -f $(echo .travis/docker/Dockerfile.$DOCKER_IMAGE_JENKINS | sed -e s/-[^-]*\$//) .travis/docker
+# docker build -t $DOCKER_IMAGE_JENKINS --build-arg CACHEBUST=$(date +%%Y%%m%%d) -f .travis/docker/Dockerfile.$DOCKER_IMAGE_JENKINS .travis/docker
 
 # travis_time_end
 set +x
 
-echo "DOCKER_CONTAINER_NAME: %(DOCKER_CONTAINER_NAME)s"
-echo "TRAVIS_BRANCH        : %(TRAVIS_BRANCH)s"
-echo "TRAVIS_COMMIT        : %(TRAVIS_COMMIT)s"
-echo "TRAVIS_PULL_REQUEST  : %(TRAVIS_PULL_REQUEST)s"
-echo "TRAVIS_REPO_SLUG     : %(TRAVIS_REPO_SLUG)s"
-echo "TRAVIS_BUILD_ID      : %(TRAVIS_BUILD_ID)s"
-echo "TRAVIS_BUILD_NUMBER  : %(TRAVIS_BUILD_NUMBER)s"
-echo "TRAVIS_JOB_ID        : %(TRAVIS_JOB_ID)s"
-echo "TRAVIS_JOB_NUMBER    : %(TRAVIS_JOB_NUMBER)s"
-echo "TRAVIS_JENKINS_UNIQUE_ID : %(TRAVIS_JENKINS_UNIQUE_ID)s"
+echo "DOCKER_CONTAINER_NAME: $DOCKER_CONTAINER_NAME"
+echo "TRAVIS_BRANCH        : $TRAVIS_BRANCH"
+echo "TRAVIS_COMMIT        : $TRAVIS_COMMIT"
+echo "TRAVIS_PULL_REQUEST  : $TRAVIS_PULL_REQUEST"
+echo "TRAVIS_REPO_SLUG     : $TRAVIS_REPO_SLUG"
+echo "TRAVIS_BUILD_ID      : $TRAVIS_BUILD_ID"
+echo "TRAVIS_BUILD_NUMBER  : $TRAVIS_BUILD_NUMBER"
+echo "TRAVIS_JOB_ID        : $TRAVIS_JOB_ID"
+echo "TRAVIS_JOB_NUMBER    : $TRAVIS_JOB_NUMBER"
+echo "TRAVIS_JENKINS_UNIQUE_ID : $TRAVIS_JENKINS_UNIQUE_ID"
+echo "ROS_DISTRO           : $ROS_DISTRO"
+echo "USE_DEB              : $USE_DEB"
+echo "EXTRA_DEB            : $EXTRA_DEB"
+echo "TEST_PKGS            : $TEST_PKGS"
+echo "TARGET_PKGS          : $TARGET_PKGS"
+echo "BEFORE_SCRIPT        : $BEFORE_SCRIPT"
+echo "NOT_TEST_INSTALL     : $NOT_TEST_INSTALL"
+echo "ROS_PARALLEL_JOBS    : $ROS_PARALLEL_JOBS"
+echo "ROS_PYTHON_VERSION   : $ROS_PYTHON_VERSION"
+echo "CATKIN_PARALLEL_JOBS        : $CATKIN_PARALLEL_JOBS"
+echo "CATKIN_TOOLS_BUILD_OPTIONS  : $CATKIN_TOOLS_BUILD_OPTIONS"
+echo "CATKIN_TOOLS_CONFIG_OPTIONS : $CATKIN_TOOLS_CONFIG_OPTIONS"
+echo "ROS_PARALLEL_TEST_JOBS      : $ROS_PARALLEL_TEST_JOBS"
+echo "CATKIN_PARALLEL_TEST_JOBS   : $CATKIN_PARALLEL_TEST_JOBS"
+echo "CMAKE_DEVELOPER_ERROR       : $CMAKE_DEVELOPER_ERROR"
+echo "BUILD_PKGS           : $BUILD_PKGS"
+echo "ROS_REPOSITORY_PATH  : $ROS_REPOSITORY_PATH"
+echo "ROSDEP_ADDITIONAL_OPTIONS   : $ROSDEP_ADDITIONAL_OPTIONS"
+echo "DOCKER_CONTAINER_NAME       : $DOCKER_CONTAINER_NAME"
+echo "DOCKER_RUN_OPTION           : $DOCKER_RUN_OPTION"
+echo "NUMBER_OF_LOGS_TO_KEEP      : $NUMBER_OF_LOGS_TO_KEEP"
+echo "REPOSITORY_NAME      : $REPOSITORY_NAME"
+echo "TRAVIS_BUILD_WEB_URL : $TRAVIS_BUILD_WEB_URL"
+echo "TRAVIS_JOB_WEB_URL   : $TRAVIS_JOB_WEB_URL"
+echo "DOCKER_IMAGE_JENKINS : $DOCKER_IMAGE_JENKINS"
+echo "ADD_ENV_VALUE_TO_DOCKER     : $ADD_ENV_VALUE_TO_DOCKER"
 
 travis_time_start setup_cache
 
 set -x
 # run watchdog for kill orphan docker container
-.travis/travis_watchdog.py %(DOCKER_CONTAINER_NAME)s &amp;
+.travis/travis_watchdog.py $DOCKER_CONTAINER_NAME &amp;
 
 # setup cache dir
-mkdir -p /data/cache/%(ROS_DISTRO)s/ccache
-mkdir -p /data/cache/%(ROS_DISTRO)s/pip-cache
-mkdir -p /data/cache/%(ROS_DISTRO)s/chainer
-mkdir -p /data/cache/%(ROS_DISTRO)s/ros/data
-mkdir -p /data/cache/%(ROS_DISTRO)s/ros/rosdep
+mkdir -p /data/cache/$ROS_DISTRO/ccache
+mkdir -p /data/cache/$ROS_DISTRO/pip-cache
+mkdir -p /data/cache/$ROS_DISTRO/chainer
+mkdir -p /data/cache/$ROS_DISTRO/ros/data
+mkdir -p /data/cache/$ROS_DISTRO/ros/rosdep
 
 # setup docker env-file
 DOCKER_ENV_FILE="/tmp/docker_env_file_$$"
 : > $DOCKER_ENV_FILE
-if [ "%(ADD_ENV_VALUE_TO_DOCKER)s" != "" ]; then
-  env_var_list=(`echo "%(ADD_ENV_VALUE_TO_DOCKER)s"`)
+if [ "$ADD_ENV_VALUE_TO_DOCKER" != "" ]; then
+  env_var_list=(`echo "$ADD_ENV_VALUE_TO_DOCKER"`)
   for env_var in ${env_var_list[@]}; do
     echo "$env_var" >> $DOCKER_ENV_FILE
   done
@@ -169,48 +355,48 @@ travis_time_end
 
 #
 docker ps -a
-if [ "$(docker ps -a | grep %(DOCKER_CONTAINER_NAME)s || true)" ] ; then
-   echo "Reanaming docker container name to %(DOCKER_CONTAINER_NAME)s_%(TRAVIS_JENKINS_UNIQUE_ID)s"
-   docker rename %(DOCKER_CONTAINER_NAME)s %(DOCKER_CONTAINER_NAME)s_%(TRAVIS_JENKINS_UNIQUE_ID)s
+if [ "$(docker ps -a | grep $DOCKER_CONTAINER_NAME || true)" ] ; then
+   echo "Reanaming docker container name to $DOCKER_CONTAINER_NAME_$TRAVIS_JENKINS_UNIQUE_ID"
+   docker rename $DOCKER_CONTAINER_NAME $DOCKER_CONTAINER_NAME_$TRAVIS_JENKINS_UNIQUE_ID
 fi
 
 travis_time_start docker_run
 
-docker run %(DOCKER_RUN_OPTION)s \\
-    --name %(DOCKER_CONTAINER_NAME)s \\
-    -e ROS_DISTRO='%(ROS_DISTRO)s' \\
-    -e USE_DEB='%(USE_DEB)s' \\
-    -e TRAVIS_REPO_SLUG='%(TRAVIS_REPO_SLUG)s' \\
-    -e EXTRA_DEB='%(EXTRA_DEB)s' \\
-    -e TARGET_PKGS='%(TARGET_PKGS)s' \\
-    -e BEFORE_SCRIPT='%(BEFORE_SCRIPT)s' \\
-    -e TEST_PKGS='%(TEST_PKGS)s' \\
-    -e NOT_TEST_INSTALL='%(NOT_TEST_INSTALL)s' \\
-    -e ROS_PARALLEL_JOBS='%(ROS_PARALLEL_JOBS)s' \\
-    -e ROS_PYTHON_VERSION='%(ROS_PYTHON_VERSION)s' \\
-    -e CATKIN_PARALLEL_JOBS='%(CATKIN_PARALLEL_JOBS)s' \\
-    -e CATKIN_TOOLS_BUILD_OPTIONS='%(CATKIN_TOOLS_BUILD_OPTIONS)s' \\
-    -e CATKIN_TOOLS_CONFIG_OPTIONS='%(CATKIN_TOOLS_CONFIG_OPTIONS)s' \\
-    -e ROS_PARALLEL_TEST_JOBS='%(ROS_PARALLEL_TEST_JOBS)s' \\
-    -e CATKIN_PARALLEL_TEST_JOBS='%(CATKIN_PARALLEL_TEST_JOBS)s' \\
-    -e CMAKE_DEVELOPER_ERROR='%(CMAKE_DEVELOPER_ERROR)s' \\
-    -e BUILD_PKGS='%(BUILD_PKGS)s' \\
-    -e ROS_REPOSITORY_PATH='%(ROS_REPOSITORY_PATH)s'  \\
-    -e ROSDEP_ADDITIONAL_OPTIONS='%(ROSDEP_ADDITIONAL_OPTIONS)s'  \\
-    -e DOCKER_RUN_OPTION='%(DOCKER_RUN_OPTION)s'  \\
+docker run $DOCKER_RUN_OPTION \\
+    --name $DOCKER_CONTAINER_NAME \\
+    -e ROS_DISTRO="$ROS_DISTRO" \\
+    -e USE_DEB="$USE_DEB" \\
+    -e TRAVIS_REPO_SLUG="$TRAVIS_REPO_SLUG" \\
+    -e EXTRA_DEB="$EXTRA_DEB" \\
+    -e TARGET_PKGS="$TARGET_PKGS" \\
+    -e BEFORE_SCRIPT="$BEFORE_SCRIPT" \\
+    -e TEST_PKGS="$TEST_PKGS" \\
+    -e NOT_TEST_INSTALL="$NOT_TEST_INSTALL" \\
+    -e ROS_PARALLEL_JOBS="$ROS_PARALLEL_JOBS" \\
+    -e ROS_PYTHON_VERSION="$ROS_PYTHON_VERSION" \\
+    -e CATKIN_PARALLEL_JOBS="$CATKIN_PARALLEL_JOBS" \\
+    -e CATKIN_TOOLS_BUILD_OPTIONS="$CATKIN_TOOLS_BUILD_OPTIONS" \\
+    -e CATKIN_TOOLS_CONFIG_OPTIONS="$CATKIN_TOOLS_CONFIG_OPTIONS" \\
+    -e ROS_PARALLEL_TEST_JOBS="$ROS_PARALLEL_TEST_JOBS" \\
+    -e CATKIN_PARALLEL_TEST_JOBS="$CATKIN_PARALLEL_TEST_JOBS" \\
+    -e CMAKE_DEVELOPER_ERROR="$CMAKE_DEVELOPER_ERROR" \\
+    -e BUILD_PKGS="$BUILD_PKGS" \\
+    -e ROS_REPOSITORY_PATH="$ROS_REPOSITORY_PATH" \\
+    -e ROSDEP_ADDITIONAL_OPTIONS="$ROSDEP_ADDITIONAL_OPTIONS" \\
+    -e DOCKER_RUN_OPTION="$DOCKER_RUN_OPTION" \\
     -e HOME=/workspace \\
     --env-file $DOCKER_ENV_FILE \\
     -v $WORKSPACE/${BUILD_TAG}:/workspace \\
-    -v /data/cache/%(ROS_DISTRO)s/ccache:/workspace/.ccache \\
-    -v /data/cache/%(ROS_DISTRO)s/pip-cache:/root/.cache/pip \\
-    -v /data/cache/%(ROS_DISTRO)s/chainer:/workspace/.chainer \\
-    -v /data/cache/%(ROS_DISTRO)s/ros/data:/workspace/.ros/data \\
-    -v /data/cache/%(ROS_DISTRO)s/ros/rosdep:/workspace/.ros/rosdep \\
+    -v /data/cache/$ROS_DISTRO/ccache:/workspace/.ccache \\
+    -v /data/cache/$ROS_DISTRO/pip-cache:/root/.cache/pip \\
+    -v /data/cache/$ROS_DISTRO/chainer:/workspace/.chainer \\
+    -v /data/cache/$ROS_DISTRO/ros/data:/workspace/.ros/data \\
+    -v /data/cache/$ROS_DISTRO/ros/rosdep:/workspace/.ros/rosdep \\
     -v /tmp/.X11-unix:/tmp/.X11-unix:rw \\
-    -w /workspace %(DOCKER_IMAGE_JENKINS)s /bin/bash \\
+    -w /workspace $DOCKER_IMAGE_JENKINS /bin/bash \\
     -c "$(cat &lt;&lt;EOL
 
-cd %(TRAVIS_REPO_SLUG)s
+cd $TRAVIS_REPO_SLUG
 set -x
 trap 'exit 1' ERR
 env
@@ -496,7 +682,43 @@ while [item for item in j.get_queue_info() if item['task']['name'] == job_name]:
 j.reconfig_job(job_name, CONFIGURE_XML % locals())
 
 ## get next number and run
-queue_number = j.build_job(job_name, {'TRAVIS_JENKINS_UNIQUE_ID':TRAVIS_JENKINS_UNIQUE_ID, 'TRAVIS_PULL_REQUEST':TRAVIS_PULL_REQUEST, 'TRAVIS_COMMIT':TRAVIS_COMMIT})
+queue_number = j.build_job(job_name, {
+    'TRAVIS_BRANCH':TRAVIS_BRANCH,
+    'TRAVIS_COMMIT':TRAVIS_COMMIT,
+    'TRAVIS_PULL_REQUEST':TRAVIS_PULL_REQUEST,
+    'TRAVIS_REPO_SLUG':TRAVIS_REPO_SLUG,
+    'TRAVIS_BUILD_ID':TRAVIS_BUILD_ID,
+    'TRAVIS_BUILD_NUMBER':TRAVIS_BUILD_NUMBER,
+    'TRAVIS_JOB_ID':TRAVIS_JOB_ID,
+    'TRAVIS_JOB_NUMBER':TRAVIS_JOB_NUMBER,
+    'TRAVIS_JENKINS_UNIQUE_ID':TRAVIS_JENKINS_UNIQUE_ID,
+    'ROS_DISTRO':ROS_DISTRO,
+    'USE_DEB':USE_DEB,
+    'EXTRA_DEB':EXTRA_DEB,
+    'TEST_PKGS':TEST_PKGS,
+    'TARGET_PKGS':TARGET_PKGS,
+    'BEFORE_SCRIPT':BEFORE_SCRIPT,
+    'NOT_TEST_INSTALL':NOT_TEST_INSTALL,
+    'ROS_PARALLEL_JOBS':ROS_PARALLEL_JOBS,
+    'ROS_PYTHON_VERSION':ROS_PYTHON_VERSION,
+    'CATKIN_PARALLEL_JOBS':CATKIN_PARALLEL_JOBS,
+    'CATKIN_TOOLS_BUILD_OPTIONS':CATKIN_TOOLS_BUILD_OPTIONS,
+    'CATKIN_TOOLS_CONFIG_OPTIONS':CATKIN_TOOLS_CONFIG_OPTIONS,
+    'ROS_PARALLEL_TEST_JOBS':ROS_PARALLEL_TEST_JOBS,
+    'CATKIN_PARALLEL_TEST_JOBS':CATKIN_PARALLEL_TEST_JOBS,
+    'CMAKE_DEVELOPER_ERROR':CMAKE_DEVELOPER_ERROR,
+    'BUILD_PKGS':BUILD_PKGS,
+    'ROS_REPOSITORY_PATH':ROS_REPOSITORY_PATH,
+    'ROSDEP_ADDITIONAL_OPTIONS':ROSDEP_ADDITIONAL_OPTIONS,
+    'DOCKER_CONTAINER_NAME':DOCKER_CONTAINER_NAME,
+    'DOCKER_RUN_OPTION':DOCKER_RUN_OPTION,
+    'NUMBER_OF_LOGS_TO_KEEP':NUMBER_OF_LOGS_TO_KEEP,
+    'REPOSITORY_NAME':REPOSITORY_NAME,
+    'TRAVIS_BUILD_WEB_URL':TRAVIS_BUILD_WEB_URL,
+    'TRAVIS_JOB_WEB_URL':TRAVIS_JOB_WEB_URL,
+    'DOCKER_IMAGE_JENKINS':DOCKER_IMAGE_JENKINS,
+    'ADD_ENV_VALUE_TO_DOCKER':ADD_ENV_VALUE_TO_DOCKER
+})
 
 # wait for queueing
 while True:

--- a/travis_jenkins.py
+++ b/travis_jenkins.py
@@ -15,6 +15,8 @@ import time
 import os
 import re
 import sys
+import random
+import string
 
 from os import environ as env
 
@@ -364,7 +366,9 @@ TRAVIS_BUILD_ID = env.get('TRAVIS_BUILD_ID')
 TRAVIS_BUILD_NUMBER = env.get('TRAVIS_BUILD_NUMBER')
 TRAVIS_JOB_ID = env.get('TRAVIS_JOB_ID')
 TRAVIS_JOB_NUMBER = env.get('TRAVIS_JOB_NUMBER')
-TRAVIS_JENKINS_UNIQUE_ID = '{}.{}'.format(TRAVIS_JOB_ID,time.time())
+TRAVIS_JENKINS_UNIQUE_ID = '{}.{}.{}'.format(time.time(),TRAVIS_JOB_ID,
+                                             ''.join(random.choice(string.digits) for _ in range(16)))
+
 ROS_DISTRO = env.get('ROS_DISTRO', 'indigo')
 USE_DEB = env.get('USE_DEB', 'true')
 EXTRA_DEB = env.get('EXTRA_DEB', '')

--- a/travis_jenkins.py
+++ b/travis_jenkins.py
@@ -121,13 +121,13 @@ if [ "%(REPOSITORY_NAME)s" = "jsk_travis" ]; then
 fi
 
 travis_time_end
-travis_time_start docker_build
+# travis_time_start docker_build
 
-# run docker build
-docker build -t %(DOCKER_IMAGE_JENKINS)s -f $(echo .travis/docker/Dockerfile.%(DOCKER_IMAGE_JENKINS)s | sed -e s/-[^-]*\$//) .travis/docker
-docker build -t %(DOCKER_IMAGE_JENKINS)s --build-arg CACHEBUST=$(date +%%Y%%m%%d) -f .travis/docker/Dockerfile.%(DOCKER_IMAGE_JENKINS)s .travis/docker
+# # run docker build
+# docker build -t %(DOCKER_IMAGE_JENKINS)s -f $(echo .travis/docker/Dockerfile.%(DOCKER_IMAGE_JENKINS)s | sed -e s/-[^-]*\$//) .travis/docker
+# docker build -t %(DOCKER_IMAGE_JENKINS)s --build-arg CACHEBUST=$(date +%%Y%%m%%d) -f .travis/docker/Dockerfile.%(DOCKER_IMAGE_JENKINS)s .travis/docker
 
-travis_time_end
+# travis_time_end
 set +x
 
 echo "DOCKER_CONTAINER_NAME: %(DOCKER_CONTAINER_NAME)s"

--- a/travis_utils.sh
+++ b/travis_utils.sh
@@ -8,10 +8,15 @@ export ANSI_CLEAR="\033[0K"
 function travis_time_start {
     set +x
     TRAVIS_START_TIME=$(date +%s%N)
-    TRAVIS_TIME_ID=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 8 | head -n 1)
+    TRAVIS_TIME_ID=$(printf "%x" $TRAVIS_START_TIME)
     TRAVIS_FOLD_NAME=$1
-    echo -e "${ANSI_CLEAR}traivs_fold:start:$TRAVIS_FOLD_NAME"
-    echo -e "${ANSI_CLEAR}traivs_time:start:$TRAVIS_TIME_ID${ANSI_BLUE}>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>${ANSI_RESET}"
+
+    if [[ "${GITHUB_ACTIONS}" == "true" ]]; then
+        echo "::group::$TRAVIS_FOLD_NAME"
+    else
+        echo -e "${ANSI_CLEAR}traivs_fold:start:$TRAVIS_FOLD_NAME"
+        echo -e "${ANSI_CLEAR}traivs_time:start:$TRAVIS_TIME_ID${ANSI_BLUE}>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>${ANSI_RESET}"
+    fi
     set -x
 }
 export -f travis_time_start
@@ -21,8 +26,12 @@ function travis_time_end {
     _COLOR=${1:-32}
     TRAVIS_END_TIME=$(date +%s%N)
     TIME_ELAPSED_SECONDS=$(( ($TRAVIS_END_TIME - $TRAVIS_START_TIME)/1000000000 ))
-    echo -e "traivs_time:end:$TRAVIS_TIME_ID:start=$TRAVIS_START_TIME,finish=$TRAVIS_END_TIME,duration=$(($TRAVIS_END_TIME - $TRAVIS_START_TIME))\n${ANSI_CLEAR}"
-    echo -e "traivs_fold:end:$TRAVIS_FOLD_NAME\e[${_COLOR}m<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<${ANSI_RESET}"
+    if [[ "${GITHUB_ACTIONS}" == "true" ]]; then
+        echo "::endgroup::"
+    else
+        echo -e "traivs_time:end:$TRAVIS_TIME_ID:start=$TRAVIS_START_TIME,finish=$TRAVIS_END_TIME,duration=$(($TRAVIS_END_TIME - $TRAVIS_START_TIME))\n${ANSI_CLEAR}"
+        echo -e "traivs_fold:end:$TRAVIS_FOLD_NAME\e[${_COLOR}m<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<${ANSI_RESET}"
+    fi
     echo -e "${ANSI_CLEAR}\e[${_COLOR}mFunction $TRAVIS_FOLD_NAME takes $(( $TIME_ELAPSED_SECONDS / 60 )) min $(( $TIME_ELAPSED_SECONDS % 60 )) sec${ANSI_RESET}"
 }
 export -f travis_time_end


### PR DESCRIPTION
- add status badge - support actions.yml, add exmaple files under .github/workflows/*.yml
- .travis.yml -> .github/workflow/main.yml
- travis_jenkins.py: send all environment variable through parameters, not config file
- do not build docker file on travis_jenkins
- use random value for TRAVIS_JENKINS_UNIQUE_ID
- somehow `cat /dev/urandom` with command substitution did not work on Github actions, not sure why

[![.github/workflows/main.yml](https://github.com/k-okada/jsk_travis/actions/workflows/main.yml/badge.svg)](https://github.com/k-okada/jsk_travis/actions/workflows/main.yml)