### PR TITLE
remove duplicate key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 #   Generic MoveIt Travis Continuous Integration Configuration File
 #   Works with all MoveIt! repositories/branches
 #   Author: Dave Coleman, Jonathan Bohren
-language: c++
 cache:
   apt: true
   pip: true


### PR DESCRIPTION
`language` key is set twice in `.travis.yml`