### PR TITLE
use old-releases.ubuntu.com for precise

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -132,7 +132,8 @@ runs:
       run: |
         export DEBIAN_FRONTEND=noninteractive
         if [ "$EUID" -eq 0 ]; then # if we run with root
-          apt-get -y -qq update
+          # check if archive.ubuntu.com is available in this distribution
+          apt-get -y -qq update || if [ $? -eq 100 ]; then sed -i 's/archive.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list; apt-get -y -qq update; fi
           apt-get -y -qq install sudo
         fi
         # install fundamental packages

--- a/docker.sh
+++ b/docker.sh
@@ -7,9 +7,11 @@ travis_time_start setup_docker
 export DEBIAN_FRONTEND=noninteractive
 
 if [ "$(which sudo)" = "" ]; then
-  apt-get -y -qq update
+  # check if archive.ubuntu.com is available in this distribution
+  apt-get -y -qq update || if [ $? -eq 100 ]; then sed -i 's/archive.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list; apt-get -y -qq update; fi
   apt-get -y -qq install sudo
 fi
+
 # install fundamental packages
 sudo -E apt-get -y -qq update
 sudo -E apt-get -y -qq install apt-utils build-essential curl git lsb-release wget

--- a/docker/Dockerfile.ros-ubuntu:12.04
+++ b/docker/Dockerfile.ros-ubuntu:12.04
@@ -5,6 +5,7 @@ FROM ubuntu:12.04
 ####
 
 # install packages
+RUN apt-get update || if [ $? -eq 100 ]; then sed -i 's/archive.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list; apt-get update; fi
 RUN apt-get update && apt-get install -q -y dirmngr gnupg2 lsb-release sudo wget
 
 # setup keys

--- a/travis_jenkins.py
+++ b/travis_jenkins.py
@@ -408,6 +408,9 @@ sudo chown -R user.jenkins /workspace/.chainer
 sudo chown -R user.jenkins /workspace/.ccache
 sudo chown -R user.jenkins /workspace/.ros
 
+# check if archive.ubuntu.com is available in this distribution
+sudo apt-get -y -qq update || if [ \$? -eq 100 ]; then sudo sed -i 's/archive.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list; fi
+
 # mkdir log dir
 mkdir log
 export ROS_LOG_DIR=\$PWD/log


### PR DESCRIPTION
`precise` is moved to `old-releases.ubuntu.com`.
this PR check `apt-get update` availability, and change the url to `old-releases.ubuntu.com` if `archive.ubuntu.com` is unavailable.

related: https://github.com/jsk-ros-pkg/jsk_robot/pull/1345