### PR TITLE
run apt-get update, after apt-add-repository ppa:git-core/ppa

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -265,6 +265,7 @@ travis_time_start setup_git
 # check git : old linux needs newer git client ?
 # https://stackoverflow.com/questions/53207973/fatal-unknown-value-for-config-protocol-version-2
 sudo add-apt-repository -y ppa:git-core/ppa
+sudo apt-get update
 sudo apt-get install -y -q git
 git --version
 git config -l


### PR DESCRIPTION
Currently we added ppa for latest git, but not updated
```
++ sudo add-apt-repository -y ppa:git-core/ppa
gpg: keyring `/tmp/tmpzihaiwwy/secring.gpg' created
gpg: keyring `/tmp/tmpzihaiwwy/pubring.gpg' created
gpg: requesting key E1DF1F24 from hkp server keyserver.ubuntu.com
gpg: /tmp/tmpzihaiwwy/trustdb.gpg: trustdb created
gpg: key E1DF1F24: public key "Launchpad PPA for Ubuntu Git Maintainers" imported
gpg: Total number processed: 1
gpg:               imported: 1  (RSA: 1)
OK
++ sudo apt-get install -y -q git
Reading package lists...
Building dependency tree...
Reading state information...
git is already the newest version.
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
++ git --version
git version 1.9.1
```