### PR TITLE
add melodic_unencrypted_git_protocol to cehck git://

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -247,6 +247,33 @@ jobs:
           ROS_DISTRO : melodic
           ROS_REPOSITORY_PATH : http://packages.ros.org/ros/ubuntu
 
+  # since https://github.blog/2021-09-01-improving-git-protocol-security-github/ we can not use git://
+  # we need to remove git:// from submodules and .rosinstall
+  melodic_unencrypted_git_protocol:
+    name: melodic_unencrypted_git_protocol
+    runs-on: ubuntu-latest
+    container : ubuntu:18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Add pr2eus repository to .travis.rosinstall
+        run: |
+          echo "- git:" >> .travis.rosinstall
+          echo "    local-name: jsk-ros-pkg/jsk_pr2eus" >> .travis.rosinstall
+          echo "    uri: https://github.com/jsk-ros-pkg/jsk_pr2eus.git" >> .travis.rosinstall
+          echo "    version: a228cc7d3bb5b26b92ed25c7d55f32a64d9d7825"  >> .travis.rosinstall
+          pwd
+          ls -al
+          cat .travis.rosinstall
+      - name: Run jsk_travis
+        uses: ./
+        with:
+          ROS_DISTRO : melodic
+          USE_DEB : false
+          TEST_PKGS : ""
+
   noetic:
     name: noetic
     runs-on: ubuntu-latest

--- a/docker/Dockerfile.ros-ubuntu:14.04-pcl1.8
+++ b/docker/Dockerfile.ros-ubuntu:14.04-pcl1.8
@@ -25,6 +25,11 @@ RUN mkdir -p ~/ros/ws_jsk_recognition/src && \
     wstool up -j -1 && \
     sudo rm -rf /var/lib/apt/lists/*
 
+# use snapshot of rosdep list
+# https://github.com/ros/rosdistro/pull/31570#issuecomment-1000497517
+RUN sudo rm /etc/ros/rosdep/sources.list.d/20-default.list && \
+    sudo wget https://gist.githubusercontent.com/cottsay/b27a46e53b8f7453bf9ff637d32ea283/raw/476b3714bb90cfbc6b8b9d068162fc6408fa7f76/30-xenial.list -O /etc/ros/rosdep/sources.list.d/30-xenial.list
+
 RUN cd ~/ros/ws_jsk_recognition/src && \
     sudo apt-get update && \
     rosdep update --include-eol-distros && \

--- a/travis.sh
+++ b/travis.sh
@@ -345,6 +345,9 @@ if [ "$USE_DEB" == false ]; then
         # install (maybe unreleased version) dependencies from source for specific ros version
         wstool merge --merge-replace -y file://$CI_SOURCE_PATH/.travis.rosinstall.$ROS_DISTRO
     fi
+    # since https://github.blog/2021-09-01-improving-git-protocol-security-github/ we can not use git://
+    # we need to remove git:// from submodules and run wstool update again
+    wstool update || find -iname .gitmodules -exec  cat {} \; -exec sed -i s@git://github@https://github@ {} \; -exec sh -c 'cd $(dirname "$1"); git submodule sync;' sh {} \; -exec cat {} \;
     wstool update
 fi
 ln -s $CI_SOURCE_PATH . # Link the repo we are testing to the new workspace


### PR DESCRIPTION
see https://github.com/jsk-ros-pkg/jsk_robot/runs/5614732290?check_suite_focus=true for failing case

```
 Cloning into '/github/home/ros/ws_jsk_robot/src/jsk-ros-pkg/jsk_pr2eus'...
  WARNING [vcstools] Command failed: 'git submodule update --init --recursive'
   run at: '/github/home/ros/ws_jsk_robot/src/jsk-ros-pkg/jsk_pr2eus'
   errcode: 1:
  Submodule '.travis' (git://github.com/jsk-ros-pkg/jsk_travis) registered for path '.travis'
  Cloning into '/github/home/ros/ws_jsk_robot/src/jsk-ros-pkg/jsk_pr2eus/.travis'...
  fatal: remote error: 
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
  fatal: clone of 'git://github.com/jsk-ros-pkg/jsk_travis' into submodule path '/github/home/ros/ws_jsk_robot/src/jsk-ros-pkg/jsk_pr2eus/.travis' failed
  Failed to clone '.travis'. Retry scheduled
  Cloning into '/github/home/ros/ws_jsk_robot/src/jsk-ros-pkg/jsk_pr2eus/.travis'...
  fatal: remote error: 
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
  fatal: clone of 'git://github.com/jsk-ros-pkg/jsk_travis' into submodule path '/github/home/ros/ws_jsk_robot/src/jsk-ros-pkg/jsk_pr2eus/.travis' failed
  Failed to clone '.travis' a second time, aborting
  [/vcstools]
  Cloning into '/github/home/ros/ws_jsk_robot/src/nao_robot'...
  Cloning into '/github/home/ros/ws_jsk_robot/src/naoqi_pose'...
  Cloning into '/github/home/ros/ws_jsk_robot/src/pepper_robot'...
  Cloning into '/github/home/ros/ws_jsk_robot/src/ros-planning/moveit_robots'...
  ERROR in config: Error processing 'jsk-ros-pkg/jsk_pr2eus' : [jsk-ros-pkg/jsk_pr2eus] Checkout of https://github.com/jsk-ros-pkg/jsk_pr2eus.git version a228cc7d3bb5b26b92ed25c7d55f32a64d9d7825 into /github/home/ros/ws_jsk_robot/src/jsk-ros-pkg/jsk_pr2eus failed.
```