### PR TITLE
move git config --add safe.directory after chown

### DIFF
--- a/.github/workflows/indigo.yml
+++ b/.github/workflows/indigo.yml
@@ -20,10 +20,10 @@ jobs:
         run: |
           set -x
           export USER=$(whoami)
-          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
           sudo mkdir -p /__w/
           sudo chmod 777 -R /__w/
           sudo chown -R $USER $HOME
+          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run jsk_travis

--- a/.github/workflows/kinetic.yml
+++ b/.github/workflows/kinetic.yml
@@ -20,10 +20,10 @@ jobs:
         run: |
           set -x
           export USER=$(whoami)
-          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
           sudo mkdir -p /__w/
           sudo chmod 777 -R /__w/
           sudo chown -R $USER $HOME
+          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run jsk_travis

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -365,10 +365,10 @@ jobs:
         run: |
           set -x
           export USER=$(whoami)
-          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
           sudo mkdir -p /__w/
           sudo chmod 777 -R /__w/
           sudo chown -R $USER $HOME
+          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/melodic.yml
+++ b/.github/workflows/melodic.yml
@@ -20,10 +20,10 @@ jobs:
         run: |
           set -x
           export USER=$(whoami)
-          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
           sudo mkdir -p /__w/
           sudo chmod 777 -R /__w/
           sudo chown -R $USER $HOME
+          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run jsk_travis

--- a/.github/workflows/noetic.yml
+++ b/.github/workflows/noetic.yml
@@ -20,10 +20,10 @@ jobs:
         run: |
           set -x
           export USER=$(whoami)
-          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
           sudo mkdir -p /__w/
           sudo chmod 777 -R /__w/
           sudo chown -R $USER $HOME
+          git config --global --add safe.directory $GITHUB_WORKSPACE || echo "OK" # Show 'could not lock config file /github/home/.gitconfig: Permission denied', but it is ok
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run jsk_travis


### PR DESCRIPTION
```
+ git config --global --add safe.directory /__w/jsk_travis/jsk_travis
error: could not lock config file /github/home/.gitconfig: Permission denied
```
https://github.com/jsk-ros-pkg/jsk_travis/runs/6121434102?check_suite_focus=true

This error does not causes CI error on `jsk_travis`, but  in repo with `submodules` like `jsk_apc`.
```
fatal: unsafe repository ('/__w/jsk_apc/jsk_apc' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/jsk_apc/jsk_apc
Error: Process completed with exit code 128.
```
https://github.com/start-jsk/jsk_apc/runs/6246483890?check_suite_focus=true