### PR TITLE
suppress test warning in catkin run_tests

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -459,15 +459,17 @@ if [ -z $TRAVIS_JOB_ID ] || [ ! -z $GITHUB_RUN_ID ] ; then
   # suppressing the output
   # - https://github.com/catkin/catkin_tools/issues/405
   # - https://github.com/ros-planning/moveit_ci/pull/18
+  # - https://github.com/catkin/catkin_tools/issues/405#issuecomment-573753780
   #catkin run_tests -i --no-deps --no-status $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS $CMAKE_ARGS_FLAGS --
-  catkin build --catkin-make-args run_tests -- -i --no-deps --no-status $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS $CMAKE_ARGS_FLAGS --
+  catkin build --catkin-make-args run_tests -- -i --no-deps --no-status $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS $CMAKE_ARGS_FLAGS --  | sed '/^[[:space:]]*$/d;/Linked/d;/Scanning/d;/Built target/d;/Symlinking/d;/Removing/d'
 else
   # on Travis
   # suppressing the output
   # - https://github.com/catkin/catkin_tools/issues/405
   # - https://github.com/ros-planning/moveit_ci/pull/18
+  # - https://github.com/catkin/catkin_tools/issues/405#issuecomment-573753780
   #travis_wait 60 catkin run_tests -i --no-deps --no-status $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS $CMAKE_ARGS_FLAGS --
-  travis_wait 60 catkin build --catkin-make-args run_tests -- -i --no-deps --no-status $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS $CMAKE_ARGS_FLAGS --
+  travis_wait 60 catkin build --catkin-make-args run_tests -- -i --no-deps --no-status $TEST_PKGS $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS $CMAKE_ARGS_FLAGS -- | sed '/^[[:space:]]*$/d;/Linked/d;/Scanning/d;/Built target/d;/Symlinking/d;/Removing/d'
 fi
 
 travis_time_end


### PR DESCRIPTION
this PR suppress warning in `catkin run_tests`.
this trick is introduced in https://github.com/catkin/catkin_tools/issues/405#issuecomment-573753780

without this PR, travis fails because of long log output.
https://app.travis-ci.com/github/start-jsk/jsk_apc/builds/251296485