### PR TITLE
Retry ppa:git-core add-apt-repository on transient Launchpad failure

### DIFF
--- a/.github/workflows/generate_action_config.py
+++ b/.github/workflows/generate_action_config.py
@@ -44,7 +44,12 @@ jobs:
 
     steps:
       - name: Install latest git ( use sudo for ros-ubuntu, remove sudo for ubuntu container), checkout@v3.0.2 uses REST API for git<2.18, which removes .git folder and does not checkout .travis submodules
-        run: sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update && sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update && sudo apt-get install -y git
+        run: |
+          sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update
+          # ppa:git-core queries Launchpad's API, which occasionally fails
+          # transiently with "user or team does not exist" under CI load.
+          for i in 1 2 3 4 5; do sudo add-apt-repository -y ppa:git-core/ppa && break || { echo "add-apt-repository failed, retrying ($i/5)"; sleep 15; }; done
+          sudo apt-get update && sudo apt-get install -y git
       - name: Before Checkout # need for actions/checkout with ros-ubuntu container
         run: sudo chown -R user:jenkins $RUNNER_WORKSPACE $HOME
       - name: Checkout

--- a/.github/workflows/indigo.yml
+++ b/.github/workflows/indigo.yml
@@ -15,7 +15,12 @@ jobs:
 
     steps:
       - name: Install latest git ( use sudo for ros-ubuntu, remove sudo for ubuntu container), checkout@v3.0.2 uses REST API for git<2.18, which removes .git folder and does not checkout .travis submodules
-        run: sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update && sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update && sudo apt-get install -y git
+        run: |
+          sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update
+          # ppa:git-core queries Launchpad's API, which occasionally fails
+          # transiently with "user or team does not exist" under CI load.
+          for i in 1 2 3 4 5; do sudo add-apt-repository -y ppa:git-core/ppa && break || { echo "add-apt-repository failed, retrying ($i/5)"; sleep 15; }; done
+          sudo apt-get update && sudo apt-get install -y git
       - name: work around permission issue  # https://github.com/actions/checkout/issues/760#issuecomment-1097501613
         run: |
           set -x

--- a/.github/workflows/kinetic.yml
+++ b/.github/workflows/kinetic.yml
@@ -15,7 +15,12 @@ jobs:
 
     steps:
       - name: Install latest git ( use sudo for ros-ubuntu, remove sudo for ubuntu container), checkout@v3.0.2 uses REST API for git<2.18, which removes .git folder and does not checkout .travis submodules
-        run: sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update && sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update && sudo apt-get install -y git
+        run: |
+          sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update
+          # ppa:git-core queries Launchpad's API, which occasionally fails
+          # transiently with "user or team does not exist" under CI load.
+          for i in 1 2 3 4 5; do sudo add-apt-repository -y ppa:git-core/ppa && break || { echo "add-apt-repository failed, retrying ($i/5)"; sleep 15; }; done
+          sudo apt-get update && sudo apt-get install -y git
       - name: work around permission issue  # https://github.com/actions/checkout/issues/760#issuecomment-1097501613
         run: |
           set -x

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -340,7 +340,12 @@ jobs:
       - name: Before Checkout # need for actoins/checkout with ros-ubuntu container
         run: sudo chown -R user:jenkins $RUNNER_WORKSPACE $HOME
       - name: Install latest git ( use sudo for ros-ubuntu, remove sudo for ubuntu container), checkout@v3.0.2 uses REST API for git<2.18, which removes .git folder and does not checkout .travis submodules
-        run: sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update && sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update && sudo apt-get install -y git
+        run: |
+          sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update
+          # ppa:git-core queries Launchpad's API, which occasionally fails
+          # transiently with "user or team does not exist" under CI load.
+          for i in 1 2 3 4 5; do sudo add-apt-repository -y ppa:git-core/ppa && break || { echo "add-apt-repository failed, retrying ($i/5)"; sleep 15; }; done
+          sudo apt-get update && sudo apt-get install -y git
       - name: work around permission issue  # https://github.com/actions/checkout/issues/760#issuecomment-1097501613
         run: |
           set -x
@@ -365,7 +370,12 @@ jobs:
       - name: Before Checkout # need for actoins/checkout with ros-ubuntu container
         run: sudo chown -R user:jenkins $RUNNER_WORKSPACE $HOME
       - name: Install latest git ( use sudo for ros-ubuntu, remove sudo for ubuntu container), checkout@v3.0.2 uses REST API for git<2.18, which removes .git folder and does not checkout .travis submodules
-        run: sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update && sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update && sudo apt-get install -y git
+        run: |
+          sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update
+          # ppa:git-core queries Launchpad's API, which occasionally fails
+          # transiently with "user or team does not exist" under CI load.
+          for i in 1 2 3 4 5; do sudo add-apt-repository -y ppa:git-core/ppa && break || { echo "add-apt-repository failed, retrying ($i/5)"; sleep 15; }; done
+          sudo apt-get update && sudo apt-get install -y git
       - name: work around permission issue  # https://github.com/actions/checkout/issues/760#issuecomment-1097501613
         run: |
           set -x

--- a/.github/workflows/melodic.yml
+++ b/.github/workflows/melodic.yml
@@ -15,7 +15,12 @@ jobs:
 
     steps:
       - name: Install latest git ( use sudo for ros-ubuntu, remove sudo for ubuntu container), checkout@v3.0.2 uses REST API for git<2.18, which removes .git folder and does not checkout .travis submodules
-        run: sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update && sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update && sudo apt-get install -y git
+        run: |
+          sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update
+          # ppa:git-core queries Launchpad's API, which occasionally fails
+          # transiently with "user or team does not exist" under CI load.
+          for i in 1 2 3 4 5; do sudo add-apt-repository -y ppa:git-core/ppa && break || { echo "add-apt-repository failed, retrying ($i/5)"; sleep 15; }; done
+          sudo apt-get update && sudo apt-get install -y git
       - name: work around permission issue  # https://github.com/actions/checkout/issues/760#issuecomment-1097501613
         run: |
           set -x

--- a/.github/workflows/noetic.yml
+++ b/.github/workflows/noetic.yml
@@ -15,7 +15,12 @@ jobs:
 
     steps:
       - name: Install latest git ( use sudo for ros-ubuntu, remove sudo for ubuntu container), checkout@v3.0.2 uses REST API for git<2.18, which removes .git folder and does not checkout .travis submodules
-        run: sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update && sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update && sudo apt-get install -y git
+        run: |
+          sudo apt-get update && sudo apt-get install -y software-properties-common && sudo apt-get update
+          # ppa:git-core queries Launchpad's API, which occasionally fails
+          # transiently with "user or team does not exist" under CI load.
+          for i in 1 2 3 4 5; do sudo add-apt-repository -y ppa:git-core/ppa && break || { echo "add-apt-repository failed, retrying ($i/5)"; sleep 15; }; done
+          sudo apt-get update && sudo apt-get install -y git
       - name: work around permission issue  # https://github.com/actions/checkout/issues/760#issuecomment-1097501613
         run: |
           set -x

--- a/travis.sh
+++ b/travis.sh
@@ -265,7 +265,10 @@ travis_time_start setup_git
 
 # check git : old linux needs newer git client ?
 # https://stackoverflow.com/questions/53207973/fatal-unknown-value-for-config-protocol-version-2
-sudo add-apt-repository -y ppa:git-core/ppa
+# add-apt-repository queries Launchpad's API to resolve the PPA owner, which
+# occasionally fails transiently with a bogus "user or team does not exist"
+# error under CI load. Retry a few times with a short backoff.
+for i in 1 2 3 4 5; do sudo add-apt-repository -y ppa:git-core/ppa && break || { echo "add-apt-repository failed, retrying ($i/5)"; sleep 15; }; done
 sudo apt-get update
 sudo apt-get install -y -q git
 git --version


### PR DESCRIPTION
## Summary
`add-apt-repository -y ppa:git-core/ppa` queries Launchpad's API to resolve the PPA owner, which occasionally fails transiently with a bogus error even though the PPA exists:
```
Cannot add PPA: 'ppa:~git-core/ubuntu/ppa'.
ERROR: '~git-core' user or team does not exist.
```
This was observed breaking `travis.sh`'s `setup_git` step under CI load (e.g. in jsk_3rdparty's `ros`/`arm` jobs, which invoke this via the `jsk_travis@master` action), forcing a full job re-run to get past it.

- `travis.sh`: wrap the `add-apt-repository` call in `setup_git` with a retry loop (5 attempts, 15s backoff).
- Applied the same fix to the per-distro CI workflows (`indigo.yml`, `kinetic.yml`, `melodic.yml`, `noetic.yml`, `main.yml`) and their generator template (`generate_action_config.py`), which have the identical pattern for jsk_travis's own CI.

## Test plan
- [x] `python3 -m py_compile generate_action_config.py`
- [x] YAML-parsed all modified workflow files
- [ ] CI on this PR exercises the retry path indirectly (can't force the underlying Launchpad flake on demand)